### PR TITLE
Add cached Elide compilation, workers, and Gradle-native tooling

### DIFF
--- a/.github/workflows/job.build.yml
+++ b/.github/workflows/job.build.yml
@@ -47,9 +47,27 @@ jobs:
       - name: "Build: Projects"
         working-directory: .
         run: ${{ matrix.gradle-command }} --stacktrace --info --no-daemon build compatibilityTest
+      - name: "Setup: Elide"
+        id: elide
+        uses: elide-dev/setup-elide@10fbf30cebffd3538c428369950dc2094137f02b
+        with:
+          version: "1.5.1+20260903"
+          telemetry: "false"
+      - name: "Integration: Native workers, caches, and formatters"
+        env:
+          ELIDE_INTEGRATION_EXECUTABLE: ${{ steps.elide.outputs.path }}
+        run: ${{ matrix.gradle-command }} --stacktrace --no-daemon realNativeIntegrationTest
       - name: "Integration: Real Elide install, compile, and run"
         working-directory: .
         run: ${{ matrix.gradle-command }} --stacktrace --info --no-daemon realRuntimeSmoke --project-prop=elide.runtime.mode=MANAGED
+      - name: "Reports: Integration results"
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: test-results-${{ matrix.os }}
+          path: |
+            elide-gradle-plugin/build/reports/tests/
+            elide-gradle-plugin/build/test-results/
 
   build-current-toolchain:
     name: "Build (Ubuntu, Java ${{ matrix.java }}, Gradle ${{ matrix.gradle-version }})"
@@ -102,6 +120,16 @@ jobs:
       - name: "Build: Java 17 baseline"
         working-directory: .
         run: gradle -Dorg.gradle.java.installations.paths="$JAVA17_HOME" --stacktrace --info --no-daemon build compatibilityTest
+      - name: "Setup: Elide"
+        id: elide
+        uses: elide-dev/setup-elide@10fbf30cebffd3538c428369950dc2094137f02b
+        with:
+          version: "1.5.1+20260903"
+          telemetry: "false"
+      - name: "Integration: Native workers, caches, and formatters"
+        env:
+          ELIDE_INTEGRATION_EXECUTABLE: ${{ steps.elide.outputs.path }}
+        run: gradle -Dorg.gradle.java.installations.paths="$JAVA17_HOME" --stacktrace --no-daemon realNativeIntegrationTest
       - name: "Build: Current consumer pair"
         working-directory: .
         run: |
@@ -111,3 +139,11 @@ jobs:
             currentToolchainConsumerTest \
             -Pelide.currentToolchain.java=${{ matrix.java }} \
             -Pelide.currentToolchain.gradle=${{ matrix.gradle-version }}
+      - name: "Reports: Integration results"
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: test-results-java-${{ matrix.java }}-gradle-${{ matrix.gradle-version }}
+          path: |
+            elide-gradle-plugin/build/reports/tests/
+            elide-gradle-plugin/build/test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ release is cut.
 - Added opt-in build-scoped Elide compiler workers using the Bazel protobuf protocol and digest-keyed classpath reuse.
 - Added cacheable staged Java/Kotlin formatting, non-mutating `elideCheckFormat`, and explicit `elideFormat` application.
 - Added explicit Gradle dependency ownership and cacheable per-source-set exports of resolved coordinates and SHA-256 hashes.
+- Required real native CI coverage for both compiler modes, HTTP caches, worker recovery, formatters, and dependency
+  verification; corrected a Gradle 7.6 instrumentation failure in the persistent compiler launcher.
 
 - Added the `dev.elide.settings` plugin for build-wide Elide runtime policy with explicit per-project opt-in.
 - Added direct, provider-backed, and version-catalog runtime version sources through the settings `elide.runtime` DSL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ release is cut.
 
 ### Added
 
+- Added relocatable Java compilation cache entries while preserving Gradle's incremental analysis and source removal.
+- Added opt-in build-scoped Elide compiler workers using the Bazel protobuf protocol and digest-keyed classpath reuse.
+- Added cacheable staged Java/Kotlin formatting, non-mutating `elideCheckFormat`, and explicit `elideFormat` application.
+- Added explicit Gradle dependency ownership and cacheable per-source-set exports of resolved coordinates and SHA-256 hashes.
+
 - Added the `dev.elide.settings` plugin for build-wide Elide runtime policy with explicit per-project opt-in.
 - Added direct, provider-backed, and version-catalog runtime version sources through the settings `elide.runtime` DSL.
 - Added shared managed-runtime coordination for parallel multi-project builds and Isolated Projects coverage.

--- a/README.md
+++ b/README.md
@@ -210,3 +210,5 @@ dependencies while constructing the task graph or storing the configuration cach
 (see Gradle's [dependency substitution rules](https://docs.gradle.org/current/userguide/resolution_rules.html#sec:dependency_substitution_rules)).
 Changes to the Elide manifest require another preparation invocation. The default example uses Gradle-owned dependency
 resolution so a fresh checkout works in one command.
+
+See [integration testing](docs/testing.md) for the required native CI suite, coverage boundaries, and benchmark follow-up.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,30 @@ old manual `elide-javac` setup.
 
 ### Dependency installation
 
+For Gradle-owned JVM dependencies, select the explicit Gradle mode:
+
+```kotlin
+import dev.elide.gradle.ElideDependencyMode
+
+elide {
+    dependencyMode.set(ElideDependencyMode.GRADLE)
+    persistentCompiler.set(true)
+}
+
+dependencies {
+    implementation(libs.guava)
+}
+
+dependencyLocking { lockAllConfigurations() }
+```
+
+This mode rejects `install = true` and the legacy Maven installer override. Gradle resolves and verifies the compiler's
+classpath using its normal repositories, version catalogs, conflict resolution, lockfiles, and offline policy.
+`elideExportDependencies` writes a sorted inventory for every Java source set under `build/elide/dependencies/`, with
+selected runtime-classpath coordinates, artifact filenames, and SHA-256 checksums. The reports are cacheable and contain no machine paths.
+They describe Gradle's selected artifacts; they do not import `elide.pkl`, read or rewrite `elide.lock.bin`, or create a
+second dependency lock. Existing Elide-manifest-driven installation remains available in the legacy mode below.
+
 Set `install = true` to run `elide install` before Java compilation. When Maven integration is enabled, the plugin
 adds the generated `.dev/dependencies/m2` repository for dependency resolution. The manifest defaults to `elide.pkl` and
 can be changed with `manifest`:
@@ -109,6 +133,48 @@ elide {
 
 Installation is opt-in and runs as a Gradle task, not while the plugin is being applied. The Elide command runs from the
 project directory; failures identify the executable, working directory, exit code, and bounded diagnostic output.
+
+### Compilation cache and persistent workers
+
+`compileJava` and `compileTestJava` retain Gradle's standard task types, classpath analysis, outputs, and lifecycle wiring.
+With `--build-cache`, compiled output can be restored after `clean` or from another checkout. Compiler executable content,
+the launcher, runtime version, platform, managed-distribution checksum, and JVM/classpath environment overrides are inputs.
+Gradle still controls incremental recompilation and stale class removal. Local and remote caches use the same task keys;
+configure your remote cache using normal Gradle settings.
+
+Set `persistentCompiler.set(true)` to use Elide's existing Bazel worker protocol. A build service keeps up to four native
+compiler processes warm, reusing compatible executable/working-directory pairs. Main and test compilation can share a
+process, while independent requests can use separate workers. Requests include content digests for classpath JARs so
+Elide can use its opt-in warm classpath cache when annotation processing and compiler flags permit it.
+
+Workers close at the end of the build; this is not a daemon shared between Gradle invocations. Each request has a five-minute
+timeout. Native worker mode does not support `forkOptions.jvmArgs`; leave persistence disabled for those configurations.
+The one-shot compiler remains the default. Explicit/PATH installations must keep accompanying toolchain resources stable;
+declare any additional compiler-affecting files or environment variables as task inputs when using a custom installation.
+
+### Java and Kotlin formatting
+
+The same settings-selected Elide runtime powers `javaformat` and `ktfmt`:
+
+```shell
+./gradlew elideCheckFormat --build-cache
+./gradlew elideFormat
+```
+
+`elideJavaFormat` and `elideKtfmt` create cacheable formatted copies under `build/elide/formatted/`. `elideCheckFormat`
+compares these copies with source files without changing them; `elideFormat` explicitly applies the changes. By default,
+these tasks cover `.java`, `.kt`, and `.kts` files under `src/`. They are opt-in tasks and do not run during compilation.
+The formatters currently use one-shot Elide invocations; the compiler worker protocol is not exposed by the formatter CLI.
+
+```kotlin
+tasks.named<dev.elide.gradle.ElideFormatTask>("elideKtfmt") {
+    arguments.set(listOf("--kotlinlang-style"))
+}
+tasks.named("check") { dependsOn("elideCheckFormat") }
+```
+
+Formatter arguments accept style/import options; check, stdin, output, and arbitrary file arguments are rejected so a
+successful cache entry always represents formatted copies of the declared sources.
 
 ### What this plugin does
 

--- a/docs/superpowers/specs/2026-09-04-native-integration-design.md
+++ b/docs/superpowers/specs/2026-09-04-native-integration-design.md
@@ -1,0 +1,28 @@
+# Native Elide Gradle integration
+
+Status: implemented slice, ready for review
+
+Base: `feat/settings-plugin`; keep the existing PR stack open.
+
+## Outcome
+
+Reuse the settings runtime for compilation and Java/Kotlin formatting. Make compiler outputs reusable through Gradle's build cache, preserve Gradle's source dependency analysis, and reuse Elide's existing Bazel protobuf worker protocol for warm compilation. Gradle owns dependency selection, verification, locking, offline resolution, and the classpath supplied to Elide.
+
+## Contracts
+
+- Keep JavaCompile and its source-set/lifecycle integration. Declare the Elide compiler identity and launcher as inputs; configure the executable at execution only after Gradle has fingerprinted those inputs. Validate this on every supported Gradle version because Gradle otherwise disables caching for arbitrary executable overrides.
+- A build service owns bounded persistent compiler processes. A process handles one request at a time; separate processes allow parallel work. Use content digests for worker inputs, bounded protocol frames, request IDs, timeout and process teardown. Elide's worker cache remains an optimization; Gradle's outputs are authoritative.
+- Format checks never mutate source files. Cache formatting of staged copies, compare those outputs with sources for checks, and apply only through explicitly invoked tasks. Java and Kotlin formatter arguments are independent inputs. Use the selected Elide distribution for both tools.
+- Gradle-native dependency mode forbids the legacy installer/local repository combination and suppresses ambient CLASSPATH. Produce a deterministic resolved-artifact inventory for inspection; do not run an independent Maven resolver during compilation. Gradle's existing lockfile and verification metadata remain authoritative. Importing Elide manifests and interpreting binary Elide lockfiles are not implemented by this slice.
+- Runtime/tool inputs, platform, compiler arguments and relevant environment must invalidate caches. Workspace and Gradle User Home relocation must preserve cache hits when content is identical.
+- Remain compatible with Gradle 7.6.4 / Java 17, with functional coverage on 8.14.5 and 9.7.1. Verify real Elide compilation and formatting in addition to deterministic fixtures.
+
+## Verification
+
+Test no-op, clean-cache restore, relocated checkout, source edit/removal, dependency change, compiler change, configuration-cache reuse and parallel modules. Test repeated worker requests and failure isolation. Test formatting checks, explicit application, cache hits, and preservation of original sources during checking. Test Gradle dependency locking and offline resolution without an Elide install.
+
+## Evidence and operational limits
+
+The cache regression exercises Gradle 7.6.4, 8.14.5, and 9.7.1, including checkout relocation and independent-source incremental compilation. The real native fixture demonstrates one worker for main/test compilation and separate outputs under parallel multi-project execution. The managed-runtime smoke lane uses persistent compilation with the pinned distribution and a real Maven dependency.
+
+The process pool is build-scoped, capped at four workers, and keyed by executable and working directory. It preserves relative-path semantics; modules with different working directories do not reuse the same process. Requests time out after five minutes. Formatters use one-shot commands because the inspected Elide formatter entry points do not expose the compiler worker protocol. Remote cache transport and Gradle User Home relocation are not separately exercised by the new tests; the task uses Gradle's cache implementation and content-based executable identity.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,54 @@
+# Integration testing
+
+Run the deterministic suites with `./gradlew build compatibilityTest`. These use Gradle TestKit consumer builds,
+local repositories, and controlled runtime fixtures, alongside unit tests for the worker protocol and lifecycle.
+
+Run the real native suite separately:
+
+```sh
+ELIDE_INTEGRATION_EXECUTABLE="$(command -v elide)" ./gradlew realNativeIntegrationTest
+./gradlew realRuntimeSmoke -Pelide.runtime.mode=MANAGED
+```
+
+On PowerShell, set `$env:ELIDE_INTEGRATION_EXECUTABLE = (Get-Command elide).Source`, then run
+`./gradlew.bat realNativeIntegrationTest`. The native task fails when its binary is missing; it never silently skips
+or restores its own test results from cache. The consumer builds inside the tests intentionally use caches.
+
+PR CI installs pinned Elide `1.5.1+20260903` with a commit-pinned `elide-dev/setup-elide` action and requires the native
+suite on Linux, macOS, and Windows, plus the current Gradle/JDK build lanes. The managed smoke test independently
+provisions its runtime with an isolated Gradle User Home and PATH, so setup-elide cannot mask a provisioning failure.
+All build lanes upload HTML and XML test reports even after failures.
+
+## Coverage contracts
+
+| Boundary | Regression evidence |
+| --- | --- |
+| Settings and provisioning | Explicit opt-in, inherited/overridden/catalog runtime versions, isolated projects, checksum failures, offline reuse, parallel provisioning; real managed install/compile/run |
+| Gradle compilation | Fixture matrix checks precise incremental source selection and compiler-content invalidation |
+| Real compilation | Gradle 7.6.4/8.14.5/9.7.1, one-shot and persistent: HTTP cache upload/restoration with local cache disabled, relocated checkout restoration, changed-source output, deleted-class cleanup; persistent compilation invalidates a replaced dependency JAR |
+| Worker service | Real main/test process reuse, compilation-error recovery in the same process, parallel module isolation and configuration-cache reuse; unit tests cover protocol framing and process shutdown |
+| Formatters | Real javaformat and ktfmt: check preserves sources, clean local-cache restoration, apply changes both languages, style changes invalidate outputs, deleted Kotlin source removes staged output, unsafe arguments rejected |
+| Gradle-owned dependencies | Transitive conflict selection, locks, offline report restoration, catalog dependency export, checksum verification rejects tampering, ambient classpath exclusion, conflicting installer rejection |
+
+Some shell-fixture tests remain Unix-only; the native compilation matrix and native formatter tests have no OS skip.
+Assertions check task outcomes and produced artifacts, not elapsed-time thresholds.
+
+## Remaining coverage and scope
+
+No suite can establish every possible compiler or project behavior. Still useful to expand: annotation processors,
+JPMS, worker crash/timeout/cancellation against a real binary, large classpath/source batches, cross-Gradle-User-Home
+cache relocation, and authenticated/TLS remote caches. The HTTP test covers transport and output correctness using a
+loopback server, not a hosted cache service. Full Elide manifest/binary-lock interoperability is not implemented and
+must not be inferred from Gradle dependency-mode tests.
+
+## Benchmark follow-up
+
+Add a separate, non-gating benchmark workflow once correctness lanes are stable. Use fixed generated projects with
+1, 10, and 50 modules and compare stock javac, one-shot Elide, and persistent Elide on identical sources and toolchains.
+Measure cold clean builds, warm no-op builds, method-body and ABI edits, clean local/remote cache restoration, and
+javaformat/ktfmt cold/warm staging. Keep compiler mode and Gradle daemon/cache state explicit.
+
+Record warmups and repeated samples, median/p95 wall time, native process count, CPU time, peak memory, runtime/JDK/
+Gradle versions, and runner hardware. Publish raw samples as artifacts; keep correctness checks alongside timings.
+Do not claim a performance gain from cache hits or worker reuse alone, and do not impose timing gates on shared CI
+runners before measuring variance and selecting a baseline.

--- a/elide-gradle-plugin/build.gradle.kts
+++ b/elide-gradle-plugin/build.gradle.kts
@@ -102,6 +102,29 @@ dependencies {
 val functionalTestTask = tasks.register<Test>("functionalTest") {
     testClassesDirs = functionalTest.output.classesDirs
     classpath = functionalTest.runtimeClasspath
+    exclude("**/RealNativeIntegrationFunctionalTest*")
+}
+
+val nativeExecutable = providers.environmentVariable("ELIDE_INTEGRATION_EXECUTABLE")
+tasks.register<Test>("realNativeIntegrationTest") {
+    group = "verification"
+    description = "Requires real Elide and verifies compilation, workers, caches, and formatters."
+    testClassesDirs = functionalTest.output.classesDirs
+    classpath = functionalTest.runtimeClasspath
+    include("**/RealNativeIntegrationFunctionalTest*")
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    })
+    // Always execute external-runtime checks; an earlier skip/cache hit must not mask missing Elide.
+    outputs.upToDateWhen { false }
+    outputs.doNotCacheIf("Verifies the installed native runtime") { true }
+    doFirst {
+        val executable = nativeExecutable.orNull
+        check(!executable.isNullOrBlank() && file(executable).isFile) {
+            "realNativeIntegrationTest requires ELIDE_INTEGRATION_EXECUTABLE pointing to an Elide binary"
+        }
+        environment("ELIDE_INTEGRATION_EXECUTABLE", executable!!)
+    }
 }
 
 val compatibilityTestTask = tasks.register<Test>("compatibilityTest") {

--- a/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/CompilationCacheFunctionalTest.java
+++ b/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/CompilationCacheFunctionalTest.java
@@ -1,0 +1,114 @@
+package dev.elide.gradle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class CompilationCacheFunctionalTest {
+    @TempDir Path directory;
+    private String gradleVersion;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"7.6.4", "8.14.5", "9.7.1"})
+    @DisabledOnOs(OS.WINDOWS)
+    void restoresCompiledClassesFromCacheAndInvalidatesChangedCompiler(String version)
+            throws Exception {
+        gradleVersion = version;
+        Path compiler = directory.resolve("elide");
+        String javac = Path.of(System.getProperty("java.home"), "bin", "javac").toString();
+        Files.writeString(
+                compiler,
+                "#!/bin/sh\n"
+                    + "shift\n"
+                    + "shift\n"
+                    + "for arg in \"$@\"; do\n"
+                    + "case \"$arg\" in\n"
+                    + "@*) cp \"${arg#@}\" compiler.last-args ;;\n"
+                    + "esac\n"
+                    + "done\n"
+                    + "exec '"
+                        + javac
+                        + "' \"$@\"\n");
+        compiler.toFile().setExecutable(true);
+        Files.writeString(
+                directory.resolve("settings.gradle"),
+                "rootProject.name='cache-test'\nbuildCache { local { directory = file('"
+                        + directory.resolve("cache").toString().replace("\\", "/")
+                        + "') } }\n");
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                """
+                plugins { id 'java'; id 'dev.elide' }
+                elide { runtime { mode = dev.elide.gradle.ElideRuntimeMode.PATH; executable = layout.projectDirectory.file('elide') } }
+                """);
+        Path source = directory.resolve("src/main/java/Example.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, "public class Example { public int value() { return 1; } }\n");
+        Files.writeString(source.resolveSibling("Unrelated.java"), "public class Unrelated {}\n");
+        assertEquals(TaskOutcome.SUCCESS, run("compileJava").task(":compileJava").getOutcome());
+        assertEquals(TaskOutcome.UP_TO_DATE, run("compileJava").task(":compileJava").getOutcome());
+        assertEquals(
+                TaskOutcome.FROM_CACHE,
+                run("clean", "compileJava").task(":compileJava").getOutcome());
+        assertTrue(Files.exists(directory.resolve("build/classes/java/main/Example.class")));
+        Path relocated = directory.resolve("relocated");
+        for (String file :
+                java.util.List.of(
+                        "elide",
+                        "settings.gradle",
+                        "build.gradle",
+                        "src/main/java/Example.java",
+                        "src/main/java/Unrelated.java")) {
+            Path target = relocated.resolve(file);
+            Files.createDirectories(target.getParent());
+            Files.copy(directory.resolve(file), target);
+        }
+        relocated.resolve("elide").toFile().setExecutable(true);
+        assertEquals(
+                TaskOutcome.FROM_CACHE,
+                GradleRunner.create()
+                        .withGradleVersion(version)
+                        .withPluginClasspath()
+                        .withProjectDir(relocated.toFile())
+                        .withArguments(
+                                "compileJava",
+                                "--build-cache",
+                                "--configuration-cache",
+                                "--stacktrace")
+                        .build()
+                        .task(":compileJava")
+                        .getOutcome());
+        Files.writeString(source, "public class Example { public int value() { return 2; } }\n");
+        assertEquals(TaskOutcome.SUCCESS, run("compileJava").task(":compileJava").getOutcome());
+        assertFalse(
+                Files.readString(directory.resolve("compiler.last-args"))
+                        .contains("Unrelated.java"),
+                "An independent source should not be recompiled after a method-body change");
+        Files.writeString(compiler, Files.readString(compiler) + "# changed compiler\n");
+        assertEquals(TaskOutcome.SUCCESS, run("compileJava").task(":compileJava").getOutcome());
+        Files.delete(source);
+        run("compileJava");
+        assertFalse(Files.exists(directory.resolve("build/classes/java/main/Example.class")));
+    }
+
+    private org.gradle.testkit.runner.BuildResult run(String... tasks) {
+        java.util.List<String> arguments = new java.util.ArrayList<>(java.util.List.of(tasks));
+        arguments.addAll(
+                java.util.List.of("--build-cache", "--configuration-cache", "--stacktrace"));
+        return GradleRunner.create()
+                .withGradleVersion(gradleVersion)
+                .withPluginClasspath()
+                .withProjectDir(directory.toFile())
+                .withArguments(arguments)
+                .build();
+    }
+}

--- a/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/CompilerIntegrationFunctionalTest.java
+++ b/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/CompilerIntegrationFunctionalTest.java
@@ -4,8 +4,6 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
@@ -243,12 +241,12 @@ class CompilerIntegrationFunctionalTest {
     }
 
     @Test
-    @EnabledOnOs(OS.WINDOWS)
-    void configuresCompilerWithAWindowsNativeFixtureWithoutExecutingIt() throws IOException {
+    void defersExecutableOverrideAndPreservesCompilerArgumentsWithoutExecutingTheFixture() throws IOException {
         Path projectDirectory = temporaryDirectory.resolve("windows-compiler-project");
         Path executable = projectDirectory.resolve("bin/elide.exe");
         Files.createDirectories(executable.getParent());
         Files.writeString(executable, "@echo off\r\nexit /b 0\r\n");
+        executable.toFile().setExecutable(true);
         writeCompilerProject(projectDirectory, executable);
         Files.writeString(projectDirectory.resolve("build.gradle"), """
 
@@ -263,12 +261,15 @@ class CompilerIntegrationFunctionalTest {
         runner(projectDirectory, Map.of()).withArguments("recordCompilerConfiguration").build();
 
         List<String> configuration = Files.readAllLines(projectDirectory.resolve("compiler-configuration.txt"));
-        assertTrue(configuration.get(0).endsWith("java.exe"), configuration.toString());
-        int launcherIndex = configuration.indexOf("dev.elide.gradle.ElideJavaCompilerLauncher");
-        assertTrue(launcherIndex >= 0, configuration.toString());
-        assertTrue(Files.isSameFile(executable, Path.of(configuration.get(launcherIndex + 1))));
-        assertEquals(List.of("javac", "--", "-Xdefinitely-not-a-java-option"),
-                configuration.subList(launcherIndex + 2, launcherIndex + 5));
+        assertEquals("null", configuration.get(0),
+                "Setting the executable during configuration would disable JavaCompile caching");
+        String configuredElide = configuration.stream()
+                .filter(value -> value.endsWith("elide.exe"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(configuration));
+        assertTrue(Files.isSameFile(executable, Path.of(configuredElide)), configuration.toString());
+        assertTrue(configuration.contains("javac"), configuration.toString());
+        assertTrue(configuration.contains("--"), configuration.toString());
     }
 
     private static void writeProject(Path projectDirectory, Path executable, String configuration) throws IOException {

--- a/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/FormattingFunctionalTest.java
+++ b/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/FormattingFunctionalTest.java
@@ -1,0 +1,60 @@
+package dev.elide.gradle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.gradle.testkit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.*;
+
+class FormattingFunctionalTest {
+    @TempDir Path directory;
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void checkPreservesSourcesAndApplyUsesCachedFormattedOutputs() throws Exception {
+        Files.writeString(
+                directory.resolve("settings.gradle"),
+                "rootProject.name='format-test'\n"
+                    + "buildCache { local { directory = file('cache') } }\n");
+        Path runtime = directory.resolve("elide");
+        Files.writeString(
+                runtime,
+                """
+                #!/bin/sh
+                shift
+                shift
+                for file in "$@"; do
+                  case "$file" in
+                    *.java|*.kt) printf 'formatted\\n' > "$file" ;;
+                  esac
+                done
+                """);
+        runtime.toFile().setExecutable(true);
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                """
+                plugins { id 'java'; id 'dev.elide' }
+                elide { runtime { mode = dev.elide.gradle.ElideRuntimeMode.PATH; executable = layout.projectDirectory.file('elide') } }
+                """);
+        Path source = directory.resolve("src/main/java/Example.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, "unformatted\n");
+        var failed = runner("elideCheckFormat").buildAndFail();
+        assertTrue(failed.getOutput().contains("src/main/java/Example.java"));
+        assertEquals("unformatted\n", Files.readString(source));
+        var applied = runner("elideFormat").build();
+        assertEquals(TaskOutcome.UP_TO_DATE, applied.task(":elideJavaFormat").getOutcome());
+        assertEquals("formatted\n", Files.readString(source));
+        runner("elideCheckFormat").build();
+    }
+
+    private GradleRunner runner(String task) {
+        return GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(directory.toFile())
+                .withArguments(task, "--configuration-cache", "--build-cache", "--stacktrace");
+    }
+}

--- a/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/GradleDependencyFunctionalTest.java
+++ b/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/GradleDependencyFunctionalTest.java
@@ -22,7 +22,7 @@ class GradleDependencyFunctionalTest {
         Files.writeString(
                 directory.resolve("settings.gradle"),
                 "rootProject.name='gradle-dependencies'\n"
-                    + "buildCache { local { directory = file('cache') } }\n");
+                        + "buildCache { local { directory = file('cache') } }\n");
         Files.writeString(
                 directory.resolve("build.gradle"),
                 """
@@ -33,7 +33,9 @@ class GradleDependencyFunctionalTest {
                 dependencyLocking { lockAllConfigurations() }
                 """);
         var result = run("elideExportDependencies", "--write-locks").build();
-        assertEquals(TaskOutcome.SUCCESS, result.task(":elideExportMainDependencies").getOutcome());
+        TaskOutcome initialOutcome = result.task(":elideExportMainDependencies").getOutcome();
+        assertTrue(initialOutcome == TaskOutcome.SUCCESS || initialOutcome == TaskOutcome.FROM_CACHE,
+                "Unexpected initial export outcome: " + initialOutcome);
         String report = Files.readString(directory.resolve("build/elide/dependencies/main.tsv"));
         assertTrue(report.contains("fixture:dep:2.0\tdep-2.0.jar\t"), report);
         assertFalse(report.contains("fixture:dep:1.0"), report);
@@ -47,6 +49,47 @@ class GradleDependencyFunctionalTest {
                         .build()
                         .task(":elideExportMainDependencies")
                         .getOutcome());
+    }
+
+    @Test
+    void catalogDependenciesAreVerifiedBeforeExportAndTamperingIsRejected() throws Exception {
+        module("dep", "1.0", "");
+        Files.createDirectories(directory.resolve("gradle"));
+        Files.writeString(
+                directory.resolve("gradle/libs.versions.toml"),
+                "[libraries]\nfixture = { module = 'fixture:dep', version = '1.0' }\n");
+        Files.writeString(
+                directory.resolve("settings.gradle"), "rootProject.name='verified-export'\n");
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                """
+                plugins { id 'java'; id 'dev.elide' }
+                elide { dependencyMode.set(dev.elide.gradle.ElideDependencyMode.GRADLE) }
+                repositories { maven { url = uri('repo') } }
+                dependencies { implementation libs.fixture }
+                """);
+        run("elideExportDependencies", "--write-verification-metadata", "sha256").build();
+        assertTrue(
+                Files.readString(directory.resolve("build/elide/dependencies/main.tsv"))
+                        .contains("fixture:dep:1.0\tdep-1.0.jar\t"));
+        Path artifact = directory.resolve("repo/fixture/dep/1.0/dep-1.0.jar");
+        try (var jar = new java.util.jar.JarOutputStream(Files.newOutputStream(artifact))) {
+            jar.putNextEntry(new java.util.jar.JarEntry("tampered.txt"));
+            jar.write(new byte[] {1, 2, 3});
+            jar.closeEntry();
+        }
+        var rejected =
+                run(
+                                "elideExportDependencies",
+                                "--refresh-dependencies",
+                                "--dependency-verification",
+                                "strict",
+                                "--no-configuration-cache")
+                        .buildAndFail();
+        assertTrue(
+                rejected.getOutput().contains("Dependency verification failed"),
+                rejected.getOutput());
+        assertTrue(rejected.getOutput().contains("dep-1.0.jar"), rejected.getOutput());
     }
 
     @Test
@@ -134,7 +177,8 @@ class GradleDependencyFunctionalTest {
     private GradleRunner run(String... tasks) {
         var arguments = new java.util.ArrayList<>(java.util.List.of(tasks));
         arguments.addAll(
-                java.util.List.of("--configuration-cache", "--build-cache", "--stacktrace", "--no-watch-fs"));
+                java.util.List.of(
+                        "--configuration-cache", "--build-cache", "--stacktrace", "--no-watch-fs"));
         return GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(directory.toFile())

--- a/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/GradleDependencyFunctionalTest.java
+++ b/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/GradleDependencyFunctionalTest.java
@@ -1,0 +1,143 @@
+package dev.elide.gradle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.gradle.testkit.runner.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.*;
+
+class GradleDependencyFunctionalTest {
+    @TempDir Path directory;
+
+    @Test
+    void exportsGradleConflictResolutionWithLockingAndOfflineReuseWithoutElide() throws Exception {
+        module("dep", "1.0", "");
+        module("dep", "2.0", "");
+        module(
+                "bridge",
+                "1.0",
+                "<dependencies><dependency><groupId>fixture</groupId><artifactId>dep</artifactId><version>2.0</version></dependency></dependencies>");
+        Files.writeString(
+                directory.resolve("settings.gradle"),
+                "rootProject.name='gradle-dependencies'\n"
+                    + "buildCache { local { directory = file('cache') } }\n");
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                """
+                plugins { id 'java'; id 'dev.elide' }
+                elide { dependencyMode.set(dev.elide.gradle.ElideDependencyMode.GRADLE) }
+                repositories { maven { url = uri('repo') } }
+                dependencies { implementation 'fixture:dep:1.0'; implementation 'fixture:bridge:1.0' }
+                dependencyLocking { lockAllConfigurations() }
+                """);
+        var result = run("elideExportDependencies", "--write-locks").build();
+        assertEquals(TaskOutcome.SUCCESS, result.task(":elideExportMainDependencies").getOutcome());
+        String report = Files.readString(directory.resolve("build/elide/dependencies/main.tsv"));
+        assertTrue(report.contains("fixture:dep:2.0\tdep-2.0.jar\t"), report);
+        assertFalse(report.contains("fixture:dep:1.0"), report);
+        assertFalse(report.contains(directory.toString()), report);
+        assertTrue(
+                Files.readString(directory.resolve("gradle.lockfile")).contains("fixture:dep:2.0"));
+        assertFalse(Files.exists(directory.resolve(".dev")));
+        assertEquals(
+                TaskOutcome.FROM_CACHE,
+                run("clean", "elideExportDependencies", "--offline")
+                        .build()
+                        .task(":elideExportMainDependencies")
+                        .getOutcome());
+    }
+
+    @Test
+    void rejectsConflictingInstallerInGradleMode() throws Exception {
+        Files.writeString(directory.resolve("settings.gradle"), "rootProject.name='conflict'\n");
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                """
+                plugins { id 'dev.elide' }
+                elide { dependencyMode.set(dev.elide.gradle.ElideDependencyMode.GRADLE); install = true }
+                """);
+        assertTrue(run("help").buildAndFail().getOutput().contains("requires install = false"));
+    }
+
+    @Test
+    @org.junit.jupiter.api.condition.DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
+    void requiresAnExplicitGradleDependencyInsteadOfAmbientClasspath() throws Exception {
+        Path ambient = directory.resolve("ambient");
+        Files.createDirectories(ambient);
+        Path dependency = directory.resolve("Unlisted.java");
+        Files.writeString(dependency, "public class Unlisted {}\n");
+        assertEquals(
+                0,
+                javax.tools.ToolProvider.getSystemJavaCompiler()
+                        .run(null, null, null, "-d", ambient.toString(), dependency.toString()));
+        Path executable = directory.resolve("elide");
+        Files.writeString(
+                executable,
+                "#!/bin/sh\nshift\nshift\nexec '"
+                        + Path.of(System.getProperty("java.home"), "bin", "javac")
+                        + "' \"$@\"\n");
+        executable.toFile().setExecutable(true);
+        Files.writeString(
+                directory.resolve("settings.gradle"), "rootProject.name='strict-classpath'\n");
+        Path build = directory.resolve("build.gradle");
+        Files.writeString(
+                build,
+                """
+                plugins { id 'java'; id 'dev.elide' }
+                elide {
+                  dependencyMode.set(dev.elide.gradle.ElideDependencyMode.GRADLE)
+                  runtime { mode = dev.elide.gradle.ElideRuntimeMode.PATH; executable = layout.projectDirectory.file('elide') }
+                }
+                """);
+        Path source = directory.resolve("src/main/java/Example.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, "public class Example extends Unlisted {}\n");
+        var environment = new java.util.HashMap<>(System.getenv());
+        environment.put("CLASSPATH", ambient.toString());
+        assertTrue(
+                run("compileJava")
+                        .withEnvironment(environment)
+                        .buildAndFail()
+                        .getOutput()
+                        .contains("cannot find symbol"));
+        Files.writeString(
+                build,
+                "\ndependencies { implementation files('ambient') }\n",
+                StandardOpenOption.APPEND);
+        run("compileJava").withEnvironment(environment).build();
+        assertTrue(Files.exists(directory.resolve("build/classes/java/main/Example.class")));
+    }
+
+    private void module(String name, String version, String dependencies) throws Exception {
+        Path folder = directory.resolve("repo/fixture/" + name + "/" + version);
+        Files.createDirectories(folder);
+        Files.writeString(
+                folder.resolve(name + "-" + version + ".pom"),
+                "<project><modelVersion>4.0.0</modelVersion><groupId>fixture</groupId><artifactId>"
+                        + name
+                        + "</artifactId><version>"
+                        + version
+                        + "</version>"
+                        + dependencies
+                        + "</project>");
+        try (var jar =
+                new java.util.jar.JarOutputStream(
+                        Files.newOutputStream(folder.resolve(name + "-" + version + ".jar")))) {
+            jar.putNextEntry(new java.util.jar.JarEntry("version.txt"));
+            jar.write(version.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            jar.closeEntry();
+        }
+    }
+
+    private GradleRunner run(String... tasks) {
+        var arguments = new java.util.ArrayList<>(java.util.List.of(tasks));
+        arguments.addAll(
+                java.util.List.of("--configuration-cache", "--build-cache", "--stacktrace", "--no-watch-fs"));
+        return GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(directory.toFile())
+                .withArguments(arguments);
+    }
+}

--- a/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/RealNativeIntegrationFunctionalTest.java
+++ b/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/RealNativeIntegrationFunctionalTest.java
@@ -1,0 +1,123 @@
+package dev.elide.gradle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.gradle.testkit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.*;
+
+/** Opt-in local verification against a real distribution; CI also runs the managed runtime lane. */
+class RealNativeIntegrationFunctionalTest {
+    @TempDir Path directory;
+
+    @Test
+    void parallelModulesKeepOutputsIsolatedWithConfigurationCacheReuse() throws Exception {
+        String runtime = System.getenv("ELIDE_INTEGRATION_EXECUTABLE");
+        Assumptions.assumeTrue(
+                runtime != null,
+                "Set ELIDE_INTEGRATION_EXECUTABLE to run the real native integration test");
+        Files.writeString(
+                directory.resolve("settings.gradle"),
+                """
+                plugins { id 'dev.elide.settings' }
+                elide { runtime { mode = dev.elide.gradle.ElideRuntimeMode.PATH } }
+                rootProject.name='parallel-native'
+                include 'a', 'b'
+                buildCache { local { directory = file('cache') } }
+                """);
+        for (String module : java.util.List.of("a", "b")) {
+            Path project = directory.resolve(module);
+            Path source = project.resolve("src/main/java/Example.java");
+            Files.createDirectories(source.getParent());
+            Files.writeString(
+                    source,
+                    "public class Example { public String value() { return \""
+                            + module
+                            + "\"; } }\n");
+            Files.writeString(
+                    project.resolve("build.gradle"),
+                    """
+                    plugins { id 'java'; id 'dev.elide' }
+                    elide {
+                      persistentCompiler.set(true)
+                      dependencyMode.set(dev.elide.gradle.ElideDependencyMode.GRADLE)
+                      runtime { executable = layout.projectDirectory.file('%s') }
+                    }
+                    """
+                            .formatted(runtime.replace("\\", "/").replace("'", "\\'")));
+        }
+        run(":a:classes", ":b:classes", "--parallel", "--max-workers=2").build();
+        byte[] a = Files.readAllBytes(directory.resolve("a/build/classes/java/main/Example.class"));
+        byte[] b = Files.readAllBytes(directory.resolve("b/build/classes/java/main/Example.class"));
+        assertFalse(java.util.Arrays.equals(a, b), "Each module must keep its own class output");
+        var reused = run(":a:classes", ":b:classes", "--parallel", "--max-workers=2").build();
+        assertTrue(reused.getOutput().contains("Reusing configuration cache"));
+        assertEquals(TaskOutcome.UP_TO_DATE, reused.task(":a:compileJava").getOutcome());
+        assertEquals(TaskOutcome.UP_TO_DATE, reused.task(":b:compileJava").getOutcome());
+    }
+
+    @Test
+    void workerCompilesMainAndTestSourcesAndFormattersCheckBothLanguages() throws Exception {
+        String runtime = System.getenv("ELIDE_INTEGRATION_EXECUTABLE");
+        Assumptions.assumeTrue(
+                runtime != null,
+                "Set ELIDE_INTEGRATION_EXECUTABLE to run the real native integration test");
+        Files.writeString(
+                directory.resolve("settings.gradle"),
+                "rootProject.name='real-native'\n"
+                    + "buildCache { local { directory = file('cache') } }\n");
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                """
+                plugins { id 'java'; id 'dev.elide' }
+                elide {
+                  runtime { mode = dev.elide.gradle.ElideRuntimeMode.PATH; executable = layout.projectDirectory.file('%s') }
+                  persistentCompiler.set(true)
+                }
+                """
+                        .formatted(runtime.replace("\\", "/").replace("'", "\\'")));
+        Path source = directory.resolve("src/main/java/Example.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, "public class Example {public int value(){return 1;}}\n");
+        Path test = directory.resolve("src/test/java/ExampleTest.java");
+        Files.createDirectories(test.getParent());
+        Files.writeString(
+                test,
+                "public class ExampleTest {public int value(){return new Example().value();}}\n");
+        Path kotlin = directory.resolve("src/main/kotlin/Example.kt");
+        Files.createDirectories(kotlin.getParent());
+        Files.writeString(kotlin, "fun example( ) = 1\n");
+        var result = run("testClasses").build();
+        assertEquals(TaskOutcome.SUCCESS, result.task(":compileJava").getOutcome());
+        assertEquals(
+                1,
+                result.getOutput().split("Started Elide compiler worker", -1).length - 1,
+                "Main and test compilation should share a native process");
+        assertTrue(Files.exists(directory.resolve("build/classes/java/test/ExampleTest.class")));
+        assertEquals(
+                TaskOutcome.UP_TO_DATE,
+                run("testClasses").build().task(":compileJava").getOutcome());
+        assertEquals(
+                TaskOutcome.FROM_CACHE,
+                run("clean", "testClasses").build().task(":compileJava").getOutcome());
+        String original = Files.readString(source);
+        run("elideCheckFormat").buildAndFail();
+        assertEquals(original, Files.readString(source));
+        run("elideFormat").build();
+        assertNotEquals(original, Files.readString(source));
+        run("elideCheckFormat").build();
+    }
+
+    private GradleRunner run(String... tasks) {
+        var args = new java.util.ArrayList<>(java.util.List.of(tasks));
+        args.addAll(
+                java.util.List.of(
+                        "--configuration-cache", "--build-cache", "--stacktrace", "--info"));
+        return GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(directory.toFile())
+                .withArguments(args);
+    }
+}

--- a/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/RealNativeIntegrationFunctionalTest.java
+++ b/elide-gradle-plugin/src/functionalTest/java/dev/elide/gradle/RealNativeIntegrationFunctionalTest.java
@@ -8,15 +8,239 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.*;
 
-/** Opt-in local verification against a real distribution; CI also runs the managed runtime lane. */
+/** Required by the realNativeIntegrationTest CI task; never silently skips missing runtimes. */
 class RealNativeIntegrationFunctionalTest {
     @TempDir Path directory;
+    private String gradleVersion;
+
+    @org.junit.jupiter.params.ParameterizedTest
+    @org.junit.jupiter.params.provider.CsvSource({
+        "7.6.4,false",
+        "7.6.4,true",
+        "8.14.5,false",
+        "8.14.5,true",
+        "9.7.1,false",
+        "9.7.1,true"
+    })
+    void remoteCacheRestoresRealClassesAndSourceChangesInvalidateBothCompilerModes(
+            String version, boolean persistent) throws Exception {
+        gradleVersion = version;
+        String runtime = System.getenv("ELIDE_INTEGRATION_EXECUTABLE");
+        assertNotNull(runtime, "Real Elide is required");
+        var entries = new java.util.concurrent.ConcurrentHashMap<String, byte[]>();
+        var hits = new java.util.concurrent.atomic.AtomicInteger();
+        var serverErrors = new java.util.concurrent.CopyOnWriteArrayList<Throwable>();
+        var server =
+                com.sun.net.httpserver.HttpServer.create(
+                        new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                "/cache/",
+                exchange -> {
+                    try (exchange) {
+                        // This tiny fixture closes each exchange; advertise it to prevent stale
+                        // reuse.
+                        exchange.getResponseHeaders().set("Connection", "close");
+                        String key = exchange.getRequestURI().getPath();
+                        if (exchange.getRequestMethod().equals("PUT")) {
+                            entries.put(key, exchange.getRequestBody().readAllBytes());
+                            exchange.sendResponseHeaders(200, -1);
+                        } else {
+                            byte[] content = entries.get(key);
+                            if (content == null) {
+                                exchange.sendResponseHeaders(404, -1);
+                            } else {
+                                hits.incrementAndGet();
+                                exchange.sendResponseHeaders(200, content.length);
+                                exchange.getResponseBody().write(content);
+                            }
+                        }
+                    } catch (Throwable failure) {
+                        serverErrors.add(failure);
+                    }
+                });
+        server.start();
+        try {
+            Files.writeString(
+                    directory.resolve("settings.gradle"),
+                    """
+                    rootProject.name='remote-native'
+                    buildCache {
+                      local { enabled = false }
+                      remote(org.gradle.caching.http.HttpBuildCache) {
+                        url = uri('http://127.0.0.1:%d/cache/')
+                        allowInsecureProtocol = true
+                        push = true
+                      }
+                    }
+                    """
+                            .formatted(server.getAddress().getPort()));
+            Files.writeString(
+                    directory.resolve("build.gradle"),
+                    """
+                    plugins { id 'java'; id 'dev.elide' }
+                    elide {
+                      persistentCompiler.set(%s)
+                      dependencyMode.set(dev.elide.gradle.ElideDependencyMode.GRADLE)
+                      runtime { mode = dev.elide.gradle.ElideRuntimeMode.PATH; executable = layout.projectDirectory.file('%s') }
+                    }
+                    """
+                            .formatted(persistent, runtime.replace("\\", "/").replace("'", "\\'")));
+            Path source = directory.resolve("src/main/java/Example.java");
+            Files.createDirectories(source.getParent());
+            Files.writeString(
+                    source, "public class Example { public int value() { return 1; } }\n");
+            Files.writeString(
+                    source.resolveSibling("Independent.java"), "public class Independent {}\n");
+            var initial = run("compileJava").build();
+            assertEquals(TaskOutcome.SUCCESS, initial.task(":compileJava").getOutcome());
+            Path compiled = directory.resolve("build/classes/java/main/Example.class");
+            byte[] original = Files.readAllBytes(compiled);
+            assertTrue(serverErrors.isEmpty(), serverErrors.toString());
+            assertFalse(
+                    entries.isEmpty(),
+                    "Compilation must upload to the HTTP cache\n" + initial.getOutput());
+            var restored = run("clean", "compileJava").build();
+            assertEquals(TaskOutcome.FROM_CACHE, restored.task(":compileJava").getOutcome());
+            assertArrayEquals(original, Files.readAllBytes(compiled));
+            assertTrue(hits.get() > 0, "Local caching is disabled: restoration must use HTTP");
+            Path relocated = directory.resolve("relocated checkout");
+            for (String file :
+                    java.util.List.of(
+                            "settings.gradle",
+                            "build.gradle",
+                            "src/main/java/Example.java",
+                            "src/main/java/Independent.java")) {
+                Path target = relocated.resolve(file);
+                Files.createDirectories(target.getParent());
+                Files.copy(directory.resolve(file), target);
+            }
+            var relocatedResult = run("compileJava").withProjectDir(relocated.toFile()).build();
+            assertEquals(TaskOutcome.FROM_CACHE, relocatedResult.task(":compileJava").getOutcome());
+            assertArrayEquals(
+                    original,
+                    Files.readAllBytes(relocated.resolve("build/classes/java/main/Example.class")));
+            Files.writeString(
+                    source, "public class Example { public int value() { return 2; } }\n");
+            assertEquals(
+                    TaskOutcome.SUCCESS,
+                    run("compileJava").build().task(":compileJava").getOutcome());
+            assertFalse(java.util.Arrays.equals(original, Files.readAllBytes(compiled)));
+            Files.delete(source);
+            run("compileJava").build();
+            assertFalse(Files.exists(compiled), "Deleted sources must not leave stale classes");
+            assertTrue(Files.exists(compiled.resolveSibling("Independent.class")));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void changedClasspathJarInvalidatesPersistentCompilation() throws Exception {
+        String runtime = System.getenv("ELIDE_INTEGRATION_EXECUTABLE");
+        assertNotNull(runtime, "Real Elide is required");
+        Files.writeString(
+                directory.resolve("settings.gradle"),
+                "rootProject.name='classpath-invalidation'\n");
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                """
+                plugins { id 'java'; id 'dev.elide' }
+                elide {
+                  persistentCompiler.set(true)
+                  dependencyMode.set(dev.elide.gradle.ElideDependencyMode.GRADLE)
+                  runtime { mode = dev.elide.gradle.ElideRuntimeMode.PATH; executable = layout.projectDirectory.file('%s') }
+                }
+                dependencies { implementation files('dependency.jar') }
+                """
+                        .formatted(runtime.replace("\\", "/").replace("'", "\\'")));
+        Path source = directory.resolve("src/main/java/Example.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(
+                source,
+                "public class Example { public int value() { return Dependency.VALUE; } }\n");
+        Path dependencySource = directory.resolve("dependency-src/Dependency.java");
+        Files.createDirectories(dependencySource.getParent());
+        Path classes = directory.resolve("dependency-classes");
+        Files.createDirectories(classes);
+        byte[] previous = null;
+        for (int value : new int[] {1, 2}) {
+            Files.writeString(
+                    dependencySource,
+                    "public class Dependency { public static final int VALUE = " + value + "; }\n");
+            assertEquals(
+                    0,
+                    javax.tools.ToolProvider.getSystemJavaCompiler()
+                            .run(
+                                    null,
+                                    null,
+                                    null,
+                                    "-d",
+                                    classes.toString(),
+                                    dependencySource.toString()));
+            try (var jar =
+                    new java.util.jar.JarOutputStream(
+                            Files.newOutputStream(directory.resolve("dependency.jar")))) {
+                jar.putNextEntry(new java.util.jar.JarEntry("Dependency.class"));
+                jar.write(Files.readAllBytes(classes.resolve("Dependency.class")));
+                jar.closeEntry();
+            }
+            var compiled = run("compileJava").build();
+            assertEquals(TaskOutcome.SUCCESS, compiled.task(":compileJava").getOutcome());
+            byte[] current =
+                    Files.readAllBytes(directory.resolve("build/classes/java/main/Example.class"));
+            if (previous != null)
+                assertFalse(
+                        java.util.Arrays.equals(previous, current),
+                        "Replacing the JAR at the same path must update the inlined constant");
+            previous = current;
+        }
+        assertFalse(
+                Files.exists(directory.resolve(".dev")),
+                "Gradle mode must not run the Elide installer");
+    }
+
+    @Test
+    void failedCompilationDoesNotPoisonTheSharedWorker() throws Exception {
+        String runtime = System.getenv("ELIDE_INTEGRATION_EXECUTABLE");
+        assertNotNull(runtime, "Real Elide is required");
+        Files.writeString(
+                directory.resolve("settings.gradle"), "rootProject.name='worker-recovery'\n");
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                """
+                plugins { id 'java'; id 'dev.elide' }
+                sourceSets { broken; healthy }
+                elide {
+                  persistentCompiler.set(true)
+                  dependencyMode.set(dev.elide.gradle.ElideDependencyMode.GRADLE)
+                  runtime { mode = dev.elide.gradle.ElideRuntimeMode.PATH; executable = layout.projectDirectory.file('%s') }
+                }
+                tasks.named('compileHealthyJava') { mustRunAfter 'compileBrokenJava' }
+                """
+                        .formatted(runtime.replace("\\", "/").replace("'", "\\'")));
+        Path broken = directory.resolve("src/broken/java/Broken.java");
+        Path healthy = directory.resolve("src/healthy/java/Healthy.java");
+        Files.createDirectories(broken.getParent());
+        Files.createDirectories(healthy.getParent());
+        Files.writeString(broken, "public class Broken extends MissingType {}\n");
+        Files.writeString(healthy, "public class Healthy {}\n");
+        var result = run("compileBrokenJava", "compileHealthyJava", "--continue").buildAndFail();
+        assertEquals(TaskOutcome.FAILED, result.task(":compileBrokenJava").getOutcome());
+        assertEquals(TaskOutcome.SUCCESS, result.task(":compileHealthyJava").getOutcome());
+        assertTrue(result.getOutput().contains("cannot find symbol"), result.getOutput());
+        assertTrue(Files.exists(directory.resolve("build/classes/java/healthy/Healthy.class")));
+        assertFalse(Files.exists(directory.resolve("build/classes/java/broken/Broken.class")));
+        assertEquals(
+                1,
+                result.getOutput().split("Started Elide compiler worker", -1).length - 1,
+                "A compilation error must not force the healthy request to start another worker");
+    }
 
     @Test
     void parallelModulesKeepOutputsIsolatedWithConfigurationCacheReuse() throws Exception {
         String runtime = System.getenv("ELIDE_INTEGRATION_EXECUTABLE");
-        Assumptions.assumeTrue(
-                runtime != null,
+        assertNotNull(
+                runtime,
                 "Set ELIDE_INTEGRATION_EXECUTABLE to run the real native integration test");
         Files.writeString(
                 directory.resolve("settings.gradle"),
@@ -61,13 +285,13 @@ class RealNativeIntegrationFunctionalTest {
     @Test
     void workerCompilesMainAndTestSourcesAndFormattersCheckBothLanguages() throws Exception {
         String runtime = System.getenv("ELIDE_INTEGRATION_EXECUTABLE");
-        Assumptions.assumeTrue(
-                runtime != null,
+        assertNotNull(
+                runtime,
                 "Set ELIDE_INTEGRATION_EXECUTABLE to run the real native integration test");
         Files.writeString(
                 directory.resolve("settings.gradle"),
                 "rootProject.name='real-native'\n"
-                    + "buildCache { local { directory = file('cache') } }\n");
+                        + "buildCache { local { directory = file('cache') } }\n");
         Files.writeString(
                 directory.resolve("build.gradle"),
                 """
@@ -103,21 +327,65 @@ class RealNativeIntegrationFunctionalTest {
                 TaskOutcome.FROM_CACHE,
                 run("clean", "testClasses").build().task(":compileJava").getOutcome());
         String original = Files.readString(source);
+        String originalKotlin = Files.readString(kotlin);
         run("elideCheckFormat").buildAndFail();
         assertEquals(original, Files.readString(source));
+        assertEquals(originalKotlin, Files.readString(kotlin));
+        var cachedFormats = run("clean", "elideJavaFormat", "elideKtfmt").build();
+        assertEquals(TaskOutcome.FROM_CACHE, cachedFormats.task(":elideJavaFormat").getOutcome());
+        assertEquals(TaskOutcome.FROM_CACHE, cachedFormats.task(":elideKtfmt").getOutcome());
         run("elideFormat").build();
         assertNotEquals(original, Files.readString(source));
+        assertNotEquals(originalKotlin, Files.readString(kotlin));
         run("elideCheckFormat").build();
+        Path stagedJava =
+                directory.resolve("build/elide/formatted/java/src/main/java/Example.java");
+        Path stagedKotlin =
+                directory.resolve("build/elide/formatted/kotlin/src/main/kotlin/Example.kt");
+        String defaultJava = Files.readString(stagedJava);
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                """
+
+                tasks.named('elideJavaFormat') { arguments.set(['--aosp']) }
+                tasks.named('elideKtfmt') { arguments.set(['--kotlinlang-style']) }
+                """,
+                StandardOpenOption.APPEND);
+        var styles = run("elideJavaFormat", "elideKtfmt").build();
+        assertEquals(TaskOutcome.SUCCESS, styles.task(":elideJavaFormat").getOutcome());
+        assertEquals(TaskOutcome.SUCCESS, styles.task(":elideKtfmt").getOutcome());
+        assertNotEquals(
+                defaultJava,
+                Files.readString(stagedJava),
+                "Changed Java style must change staged output");
+        Files.delete(kotlin);
+        run("elideKtfmt").build();
+        assertFalse(
+                Files.exists(stagedKotlin),
+                "Removed Kotlin source must not leave stale staged output");
+        Files.writeString(
+                directory.resolve("build.gradle"),
+                "\ntasks.named('elideJavaFormat') { arguments.set(['--dry-run']) }\n",
+                StandardOpenOption.APPEND);
+        var invalid = run("elideJavaFormat").buildAndFail();
+        assertTrue(invalid.getOutput().contains("Unsupported formatter style option"));
     }
 
     private GradleRunner run(String... tasks) {
         var args = new java.util.ArrayList<>(java.util.List.of(tasks));
         args.addAll(
                 java.util.List.of(
-                        "--configuration-cache", "--build-cache", "--stacktrace", "--info"));
-        return GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(directory.toFile())
-                .withArguments(args);
+                        "--configuration-cache",
+                        "--build-cache",
+                        "--stacktrace",
+                        "--info",
+                        "--no-watch-fs"));
+        var runner =
+                GradleRunner.create()
+                        .withPluginClasspath()
+                        .withProjectDir(directory.toFile())
+                        .withArguments(args);
+        if (gradleVersion != null) runner.withGradleVersion(gradleVersion);
+        return runner;
     }
 }

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideCompilerArgumentProvider.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideCompilerArgumentProvider.java
@@ -3,9 +3,11 @@ package dev.elide.gradle;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.process.CommandLineArgumentProvider;
@@ -16,7 +18,7 @@ import java.util.List;
 /** Supplies the selected Elide compiler launcher inputs when Java compilation executes. */
 public abstract class ElideCompilerArgumentProvider implements CommandLineArgumentProvider {
     @InputFile
-    @PathSensitive(PathSensitivity.ABSOLUTE)
+    @PathSensitive(PathSensitivity.NONE)
     public abstract RegularFileProperty getElideExecutable();
 
     @Classpath
@@ -25,12 +27,30 @@ public abstract class ElideCompilerArgumentProvider implements CommandLineArgume
     @Input
     public abstract ListProperty<String> getForwardedJvmArguments();
 
+    @Input public abstract Property<Boolean> getPersistentCompiler();
+    @Input public abstract Property<ElideDependencyMode> getDependencyMode();
+    @Internal public abstract Property<ElideCompilerService> getCompilerService();
+    @Internal public abstract ConfigurableFileCollection getWorkerClasspath();
+
     @Override
     public Iterable<String> asArguments() {
         List<String> arguments = new ArrayList<>(6 + getForwardedJvmArguments().get().size());
         arguments.add("-cp");
         arguments.add(getLauncherClasspath().getAsPath());
         arguments.add(ElideJavaCompilerLauncher.class.getName());
+        if (!getPersistentCompiler().get() && getDependencyMode().get() == ElideDependencyMode.GRADLE) {
+            arguments.add("--gradle-classpath");
+        }
+        if (getPersistentCompiler().get()) {
+            if (!getForwardedJvmArguments().get().isEmpty()) {
+                throw new IllegalArgumentException("persistentCompiler does not support forkOptions.jvmArgs; disable it for this compiler configuration");
+            }
+            arguments.add("--worker");
+            arguments.add(getCompilerService().get().endpoint());
+            // Keep large classpaths inside the service instead of on the OS command line.
+            arguments.add("request=" + getCompilerService().get().registerCompiler(
+                    getElideExecutable().get().getAsFile().getAbsolutePath(), getWorkerClasspath().getFiles()));
+        }
         arguments.add(getElideExecutable().get().getAsFile().getAbsolutePath());
         arguments.add("javac");
         arguments.add("--");

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideCompilerService.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideCompilerService.java
@@ -1,0 +1,205 @@
+package dev.elide.gradle;
+
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import java.io.*;
+import java.net.*;
+import java.nio.file.*;
+import java.security.MessageDigest;
+import java.util.*;
+import java.util.concurrent.*;
+
+/** Build-scoped authenticated loopback bridge from JavaCompile launchers to warm Elide workers. */
+public abstract class ElideCompilerService
+        implements BuildService<BuildServiceParameters.None>, AutoCloseable {
+    private final List<Entry> workers = new ArrayList<>();
+    private boolean closed;
+
+    private static final class Entry {
+        final String key;
+        final ElideWorkerProcess process;
+        boolean busy;
+
+        Entry(String key, ElideWorkerProcess process) {
+            this.key = key;
+            this.process = process;
+        }
+    }
+
+    private final String token = UUID.randomUUID().toString();
+    private final ExecutorService clients =
+            Executors.newFixedThreadPool(
+                    4,
+                    r -> {
+                        Thread t = new Thread(r, "elide-compiler-client");
+                        t.setDaemon(true);
+                        return t;
+                    });
+    private ServerSocket server;
+    private final Set<Socket> connections = ConcurrentHashMap.newKeySet();
+
+    private record Prepared(String executable, List<File> classpath) {}
+
+    private final Map<String, Prepared> prepared = new ConcurrentHashMap<>();
+
+    public String registerCompiler(String executable, Collection<File> classpath) {
+        String id = UUID.randomUUID().toString();
+        prepared.put(id, new Prepared(executable, List.copyOf(classpath)));
+        return id;
+    }
+
+    public synchronized String endpoint() {
+        if (closed) throw new IllegalStateException("Elide compiler service is closed");
+        if (server == null) {
+            try {
+                server = new ServerSocket(0, 16, InetAddress.getLoopbackAddress());
+                Thread acceptor =
+                        new Thread(
+                                () -> {
+                                    while (!server.isClosed()) {
+                                        try {
+                                            Socket socket = server.accept();
+                                            connections.add(socket);
+                                            clients.execute(() -> handle(socket));
+                                        } catch (IOException
+                                                | RejectedExecutionException exception) {
+                                            if (!server.isClosed()) close();
+                                            return;
+                                        }
+                                    }
+                                },
+                                "elide-compiler-accept");
+                acceptor.setDaemon(true);
+                acceptor.start();
+            } catch (IOException exception) {
+                throw new UncheckedIOException(exception);
+            }
+        }
+        return server.getLocalPort() + ":" + token;
+    }
+
+    private void handle(Socket socket) {
+        try (socket) {
+            socket.setSoTimeout(300_000);
+            DataInputStream in = new DataInputStream(socket.getInputStream());
+            DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+            if (!MessageDigest.isEqual(
+                    token.getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                    in.readUTF().getBytes(java.nio.charset.StandardCharsets.UTF_8))) return;
+            String executable = in.readUTF();
+            Path cwd = Path.of(in.readUTF());
+            Prepared request = prepared.remove(in.readUTF());
+            if (request == null || !request.executable().equals(executable))
+                throw new IOException("Unknown compiler request");
+            int count = in.readInt();
+            if (count < 0 || count > 100_000)
+                throw new IOException("Invalid compiler argument count");
+            List<String> arguments = new ArrayList<>();
+            long argumentBytes = 0;
+            for (int i = 0; i < count; i++) {
+                String argument = in.readUTF();
+                argumentBytes += argument.length() * 3L;
+                if (argumentBytes > ElideWorkerProtocol.MAX_FRAME)
+                    throw new IOException("Compiler arguments exceed 64 MiB");
+                arguments.add(argument);
+            }
+            ElideWorkerProtocol.Response response;
+            try {
+                Map<String, byte[]> inputs = digests(request.classpath());
+                Entry entry = acquire(executable, cwd);
+                try {
+                    response = entry.process.compile(arguments, inputs);
+                } finally {
+                    release(entry);
+                }
+            } catch (IOException exception) {
+                response =
+                        new ElideWorkerProtocol.Response(
+                                1, "Elide compiler worker failed: " + exception.getMessage(), 0);
+            }
+            byte[] output = response.output().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            out.writeInt(response.exitCode());
+            out.writeInt(output.length);
+            out.write(output);
+            out.flush();
+        } catch (IOException ignored) {
+            // A disconnected launcher has no recipient for a response.
+        } finally {
+            connections.remove(socket);
+        }
+    }
+
+    private static Map<String, byte[]> digests(List<File> classpath) throws IOException {
+        Map<String, byte[]> digests = new TreeMap<>();
+        for (File entry : classpath) {
+            Path file = entry.toPath().toAbsolutePath().normalize();
+            // Elide deliberately bypasses its warm classpath cache for directory entries.
+            if (!Files.isRegularFile(file)) continue;
+            try {
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                try (InputStream input = Files.newInputStream(file)) {
+                    byte[] buffer = new byte[65536];
+                    int read;
+                    while ((read = input.read(buffer)) != -1) digest.update(buffer, 0, read);
+                }
+                digests.put(file.toString(), digest.digest());
+            } catch (java.security.NoSuchAlgorithmException impossible) {
+                throw new AssertionError(impossible);
+            }
+        }
+        return digests;
+    }
+
+    private synchronized Entry acquire(String executable, Path cwd) throws IOException {
+        if (closed) throw new IOException("Elide compiler service is closed");
+        String key = executable + "\n" + cwd;
+        for (Entry entry : workers) {
+            if (!entry.busy && entry.key.equals(key) && entry.process.isAlive()) {
+                entry.busy = true;
+                return entry;
+            }
+        }
+        // Four client handlers bound simultaneous compiles and the number of retained processes.
+        if (workers.size() >= 4) {
+            Entry idle =
+                    workers.stream()
+                            .filter(entry -> !entry.busy)
+                            .findFirst()
+                            .orElseThrow(() -> new IOException("Elide worker pool exhausted"));
+            idle.process.close();
+            workers.remove(idle);
+        }
+        Entry entry = new Entry(key, new ElideWorkerProcess(executable, cwd));
+        entry.busy = true;
+        workers.add(entry);
+        return entry;
+    }
+
+    private synchronized void release(Entry entry) {
+        entry.busy = false;
+    }
+
+    @Override
+    public synchronized void close() {
+        closed = true;
+        if (server != null) {
+            try {
+                server.close();
+            } catch (IOException ignored) {
+            }
+        }
+        clients.shutdownNow();
+        connections.forEach(
+                socket -> {
+                    try {
+                        socket.close();
+                    } catch (IOException ignored) {
+                    }
+                });
+        connections.clear();
+        prepared.clear();
+        workers.forEach(entry -> entry.process.close());
+        workers.clear();
+    }
+}

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideDependencies.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideDependencies.java
@@ -1,0 +1,94 @@
+package dev.elide.gradle;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+final class ElideDependencies {
+    static void configure(Project project) {
+        var aggregate =
+                project.getTasks()
+                        .register(
+                                "elideExportDependencies",
+                                task -> {
+                                    task.setGroup("Elide");
+                                    task.setDescription(
+                                            "Exports Gradle-selected JVM artifact coordinates and"
+                                                + " SHA-256 checksums.");
+                                });
+        project.getPluginManager()
+                .withPlugin("java", ignored -> configureSourceSets(project, aggregate));
+    }
+
+    private static void configureSourceSets(Project project, TaskProvider<Task> aggregate) {
+        project.getExtensions()
+                .getByType(SourceSetContainer.class)
+                .configureEach(
+                        sourceSet -> {
+                            var report = registerReport(project, sourceSet);
+                            aggregate.configure(task -> task.dependsOn(report));
+                        });
+    }
+
+    private static TaskProvider<ElideDependencyReportTask> registerReport(
+            Project project, SourceSet sourceSet) {
+        var configuration =
+                project.getConfigurations()
+                        .getByName(sourceSet.getRuntimeClasspathConfigurationName());
+        var artifacts = configuration.getIncoming().getArtifacts();
+        String name = sourceSet.getName();
+        String suffix = Character.toUpperCase(name.charAt(0)) + name.substring(1);
+        return project.getTasks()
+                .register(
+                        "elideExport" + suffix + "Dependencies",
+                        ElideDependencyReportTask.class,
+                        task -> {
+                            task.setGroup("Elide");
+                            task.dependsOn(artifacts.getArtifactFiles());
+                            task.getArtifacts()
+                                    .set(
+                                            artifacts
+                                                    .getResolvedArtifacts()
+                                                    .map(ElideDependencies::describeArtifacts));
+                            task.getReportFile()
+                                    .set(
+                                            project.getLayout()
+                                                    .getBuildDirectory()
+                                                    .file("elide/dependencies/" + name + ".tsv"));
+                        });
+    }
+
+    private static List<ElideDependencyReportTask.Artifact> describeArtifacts(
+            Set<ResolvedArtifactResult> artifacts) {
+        return artifacts.stream()
+                .filter(artifact -> artifact.getFile().isFile())
+                .map(ElideDependencies::describeArtifact)
+                .sorted(
+                        Comparator.comparing(ElideDependencyReportTask.Artifact::getCoordinate)
+                                .thenComparing(artifact -> artifact.getFile().getName()))
+                .toList();
+    }
+
+    private static ElideDependencyReportTask.Artifact describeArtifact(
+            ResolvedArtifactResult artifact) {
+        var id = artifact.getId().getComponentIdentifier();
+        String coordinate;
+        if (id instanceof ModuleComponentIdentifier module) {
+            coordinate = module.getGroup() + ":" + module.getModule() + ":" + module.getVersion();
+        } else if (id instanceof ProjectComponentIdentifier project) {
+            coordinate = "project:" + project.getProjectPath();
+        } else {
+            coordinate = "file:" + artifact.getFile().getName();
+        }
+        return new ElideDependencyReportTask.Artifact(coordinate, artifact.getFile());
+    }
+}

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideDependencyMode.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideDependencyMode.java
@@ -1,0 +1,9 @@
+package dev.elide.gradle;
+
+/** Selects whether Gradle exclusively owns JVM dependency resolution. */
+public enum ElideDependencyMode {
+    /** Preserve the opt-in legacy Elide installer and generated Maven repository. */
+    LEGACY,
+    /** Gradle resolves the classpath, including locking, verification and offline policy. */
+    GRADLE
+}

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideDependencyReportTask.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideDependencyReportTask.java
@@ -34,7 +34,7 @@ public abstract class ElideDependencyReportTask extends DefaultTask {
         }
 
         @InputFile
-        @PathSensitive(PathSensitivity.NAME_ONLY)
+        @PathSensitive(PathSensitivity.NONE)
         public File getFile() {
             return file;
         }

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideDependencyReportTask.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideDependencyReportTask.java
@@ -1,0 +1,67 @@
+package dev.elide.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.*;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.*;
+
+import java.io.*;
+import java.nio.file.*;
+import java.security.*;
+import java.util.*;
+
+/** Auditable, portable inventory of the exact artifacts selected and verified by Gradle. */
+@CacheableTask
+public abstract class ElideDependencyReportTask extends DefaultTask {
+    @Nested
+    public abstract ListProperty<Artifact> getArtifacts();
+
+    @OutputFile
+    public abstract RegularFileProperty getReportFile();
+
+    public static final class Artifact implements Serializable {
+        private final String coordinate;
+        private final File file;
+
+        public Artifact(String coordinate, File file) {
+            this.coordinate = coordinate;
+            this.file = file;
+        }
+
+        @Input
+        public String getCoordinate() {
+            return coordinate;
+        }
+
+        @InputFile
+        @PathSensitive(PathSensitivity.NAME_ONLY)
+        public File getFile() {
+            return file;
+        }
+    }
+
+    @TaskAction
+    public void writeReport() throws IOException, NoSuchAlgorithmException {
+        List<String> lines = new ArrayList<>();
+        lines.add("# Gradle-resolved Elide JVM dependencies; coordinate, artifact, SHA-256");
+        for (Artifact artifact : getArtifacts().get()) {
+            File file = artifact.getFile();
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (InputStream input = Files.newInputStream(file.toPath())) {
+                byte[] buffer = new byte[65536];
+                int read;
+                while ((read = input.read(buffer)) != -1) digest.update(buffer, 0, read);
+            }
+            lines.add(
+                    artifact.getCoordinate()
+                            + "\t"
+                            + file.getName()
+                            + "\t"
+                            + HexFormat.of().formatHex(digest.digest()));
+        }
+        Collections.sort(lines.subList(1, lines.size()));
+        Path report = getReportFile().get().getAsFile().toPath();
+        Files.createDirectories(report.getParent());
+        Files.write(report, lines);
+    }
+}

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideExtension.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideExtension.java
@@ -36,6 +36,12 @@ public class ElideExtension implements ElideExtensionConfig {
     protected Property<Boolean> enableDebugMode;
     protected Property<Boolean> enableVerboseMode;
     private final ElideProjectRuntimeSettings runtime;
+    private final Property<Boolean> persistentCompiler;
+    private final Property<ElideDependencyMode> dependencyMode;
+
+    /** Reuse Elide's Bazel compiler worker during this Gradle build. */
+    public Property<Boolean> getPersistentCompiler() { return persistentCompiler; }
+    public Property<ElideDependencyMode> getDependencyMode() { return dependencyMode; }
     @PathSensitive(PathSensitivity.RELATIVE) protected RegularFileProperty projectManifest;
     @PathSensitive(PathSensitivity.ABSOLUTE) protected RegularFileProperty activeElideBin;
     @PathSensitive(PathSensitivity.RELATIVE) protected DirectoryProperty activeDevRoot;
@@ -129,6 +135,8 @@ public class ElideExtension implements ElideExtensionConfig {
             ObjectFactory objects,
             Provider<ElideBuildConfiguration> buildConfiguration) {
         this.activeProject = project;
+        this.persistentCompiler = objects.property(Boolean.class).convention(false);
+        this.dependencyMode = objects.property(ElideDependencyMode.class).convention(ElideDependencyMode.LEGACY);
         this.doEnableInstall = objects.property(Boolean.class).convention(enableInstall);
         this.doEmbeddedBuild = objects.property(Boolean.class).convention(useBuildEmbedded);
         this.doUseMavenIntegration = objects.property(Boolean.class).convention(enableMavenIntegration);

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideFormatSourcesTask.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideFormatSourcesTask.java
@@ -1,0 +1,63 @@
+package dev.elide.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.*;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.*;
+import org.gradle.work.DisableCachingByDefault;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.*;
+
+/** Compares staged formatting outputs or explicitly applies them to source files. */
+@DisableCachingByDefault(
+        because = "Checks current sources or explicitly updates them; formatting itself is cached.")
+public abstract class ElideFormatSourcesTask extends DefaultTask {
+    @Input
+    public abstract Property<Boolean> getApplyChanges();
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getFormattedDirectories();
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getSources();
+
+    @Internal
+    public abstract DirectoryProperty getSourceRoot();
+
+    @TaskAction
+    public void checkOrApply() throws IOException {
+        Path root = getSourceRoot().get().getAsFile().toPath();
+        Set<Path> allowed = new HashSet<>();
+        getSources()
+                .getFiles()
+                .forEach(file -> allowed.add(file.toPath().toAbsolutePath().normalize()));
+        List<String> changed = new ArrayList<>();
+        for (var directory : getFormattedDirectories()) {
+            Path staged = directory.toPath();
+            if (!Files.isDirectory(staged)) continue;
+            try (var files = Files.walk(staged)) {
+                for (Path file : files.filter(Files::isRegularFile).sorted().toList()) {
+                    Path relative = staged.relativize(file);
+                    Path source = root.resolve(relative).toAbsolutePath().normalize();
+                    if (!allowed.contains(source))
+                        throw new GradleException("Unexpected formatter output: " + relative);
+                    if (Files.mismatch(file, source) != -1) {
+                        changed.add(relative.toString());
+                        if (getApplyChanges().get())
+                            Files.copy(file, source, StandardCopyOption.REPLACE_EXISTING);
+                    }
+                }
+            }
+        }
+        if (!getApplyChanges().get() && !changed.isEmpty()) {
+            throw new GradleException(
+                    "Formatting required; run elideFormat:\n" + String.join("\n", changed));
+        }
+        setDidWork(!changed.isEmpty());
+    }
+}

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideFormatTask.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideFormatTask.java
@@ -1,0 +1,129 @@
+package dev.elide.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.*;
+import org.gradle.api.provider.*;
+import org.gradle.api.tasks.*;
+import org.gradle.process.ExecOperations;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+
+import javax.inject.Inject;
+
+/** Formats staged copies so cache restoration and verification never overwrite source files. */
+@CacheableTask
+public abstract class ElideFormatTask extends DefaultTask {
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract RegularFileProperty getElideExecutable();
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @IgnoreEmptyDirectories
+    public abstract ConfigurableFileCollection getSources();
+
+    @Input
+    public abstract Property<String> getTool();
+
+    @Input
+    public abstract ListProperty<String> getArguments();
+
+    @Internal
+    public abstract DirectoryProperty getSourceRoot();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getDestinationDirectory();
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
+
+    public ElideFormatTask() {
+        getArguments().convention(List.of());
+    }
+
+    @Input
+    public List<String> getRelativeSourcePaths() {
+        Path root = getSourceRoot().get().getAsFile().toPath();
+        return getSources().getFiles().stream()
+                .map(file -> root.relativize(file.toPath()).toString())
+                .sorted()
+                .toList();
+    }
+
+    @TaskAction
+    public void format() throws IOException {
+        Set<String> allowed =
+                getTool().get().equals("ktfmt")
+                        ? Set.of(
+                                "--meta-style",
+                                "--google-style",
+                                "--kotlinlang-style",
+                                "--do-not-remove-unused-imports")
+                        : Set.of(
+                                "--aosp",
+                                "--fix-imports-only",
+                                "--skip-sorting-imports",
+                                "--skip-removing-unused-imports",
+                                "--skip-reflowing-long-strings",
+                                "--skip-javadoc-formatting");
+        for (String argument : getArguments().get()) {
+            if (!allowed.contains(argument))
+                throw new GradleException("Unsupported formatter style option: " + argument);
+        }
+        Path root = getSourceRoot().get().getAsFile().toPath();
+        Path output = getDestinationDirectory().get().getAsFile().toPath();
+        if (root.startsWith(output)
+                || getSources().getFiles().stream()
+                        .anyMatch(file -> file.toPath().startsWith(output))) {
+            throw new GradleException("Formatter destination must not contain project sources");
+        }
+        if (Files.exists(output)) {
+            try (var files = Files.walk(output)) {
+                for (Path file : files.sorted(Comparator.reverseOrder()).toList())
+                    Files.delete(file);
+            }
+        }
+        Files.createDirectories(output);
+        List<String> sources = new ArrayList<>();
+        for (File source : getSources().getFiles().stream().sorted().toList()) {
+            Path relative = root.relativize(source.toPath());
+            if (relative.startsWith(".."))
+                throw new GradleException("Formatter source must be inside the project: " + source);
+            Path destination = output.resolve(relative);
+            Files.createDirectories(destination.getParent());
+            Files.copy(source.toPath(), destination, StandardCopyOption.REPLACE_EXISTING);
+            sources.add("./" + relative.toString());
+        }
+        // Keep argument vectors bounded on Windows while retaining filenames containing spaces.
+        List<String> batch = new ArrayList<>();
+        int length = 0;
+        for (String source : sources) {
+            if (length + source.length() > 4000 && !batch.isEmpty()) {
+                execute(output, batch);
+                batch.clear();
+                length = 0;
+            }
+            batch.add(source);
+            length += source.length() + 3;
+        }
+        if (!batch.isEmpty()) execute(output, batch);
+    }
+
+    private void execute(Path output, List<String> sources) {
+        List<String> args = new ArrayList<>(List.of(getTool().get(), "--"));
+        args.addAll(getArguments().get());
+        if (getTool().get().equals("javaformat")) args.add("--replace");
+        args.addAll(sources);
+        getExecOperations()
+                .exec(
+                        spec -> {
+                            spec.executable(getElideExecutable().get().getAsFile());
+                            spec.setWorkingDir(output.toFile());
+                            spec.args(args);
+                        })
+                .assertNormalExitValue();
+    }
+}

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideFormatting.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideFormatting.java
@@ -1,0 +1,79 @@
+package dev.elide.gradle;
+
+import org.gradle.api.Project;
+
+import java.util.List;
+
+final class ElideFormatting {
+    static void configure(Project project, ElideRuntimeResolution runtime) {
+        var javaSources = project.fileTree("src", tree -> tree.include("**/*.java"));
+        var kotlinSources = project.fileTree("src", tree -> tree.include("**/*.kt", "**/*.kts"));
+        var java =
+                project.getTasks()
+                        .register(
+                                "elideJavaFormat",
+                                ElideFormatTask.class,
+                                task -> {
+                                    task.setGroup("formatting");
+                                    task.setDescription(
+                                            "Formats Java source copies with Elide javaformat.");
+                                    task.getTool().set("javaformat");
+                                    task.getSources().from(javaSources);
+                                    task.getSourceRoot()
+                                            .set(project.getLayout().getProjectDirectory());
+                                    task.getDestinationDirectory()
+                                            .set(
+                                                    project.getLayout()
+                                                            .getBuildDirectory()
+                                                            .dir("elide/formatted/java"));
+                                    task.getElideExecutable().set(runtime.executable());
+                                    ElideTaskInputs.runtime(task, runtime);
+                                    task.dependsOn(runtime.preparationTask());
+                                });
+        var kotlin =
+                project.getTasks()
+                        .register(
+                                "elideKtfmt",
+                                ElideFormatTask.class,
+                                task -> {
+                                    task.setGroup("formatting");
+                                    task.setDescription(
+                                            "Formats Kotlin source copies with Elide ktfmt.");
+                                    task.getTool().set("ktfmt");
+                                    task.getSources().from(kotlinSources);
+                                    task.getSourceRoot()
+                                            .set(project.getLayout().getProjectDirectory());
+                                    task.getDestinationDirectory()
+                                            .set(
+                                                    project.getLayout()
+                                                            .getBuildDirectory()
+                                                            .dir("elide/formatted/kotlin"));
+                                    task.getElideExecutable().set(runtime.executable());
+                                    ElideTaskInputs.runtime(task, runtime);
+                                    task.dependsOn(runtime.preparationTask());
+                                });
+        for (String name : List.of("elideCheckFormat", "elideFormat")) {
+            project.getTasks()
+                    .register(
+                            name,
+                            ElideFormatSourcesTask.class,
+                            task -> {
+                                task.setGroup("formatting");
+                                task.setDescription(
+                                        name.equals("elideFormat")
+                                                ? "Applies Elide formatting to project sources."
+                                                : "Checks project formatting without modifying"
+                                                      + " sources.");
+                                task.getApplyChanges().set(name.equals("elideFormat"));
+                                task.getSourceRoot().set(project.getLayout().getProjectDirectory());
+                                task.getSources().from(javaSources, kotlinSources);
+                                task.getFormattedDirectories()
+                                        .from(
+                                                java.flatMap(
+                                                        ElideFormatTask::getDestinationDirectory),
+                                                kotlin.flatMap(
+                                                        ElideFormatTask::getDestinationDirectory));
+                            });
+        }
+    }
+}

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideGradlePlugin.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideGradlePlugin.java
@@ -9,7 +9,6 @@ import org.gradle.api.tasks.compile.JavaCompile;
 
 import java.io.File;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.util.List;
 
 /** Gradle integration for Elide runtime selection, compilation, and dependency installation. */
@@ -32,6 +31,8 @@ public class ElideGradlePlugin implements Plugin<Project> {
         ElideExtension extension = project.getExtensions().create(
                 ELIDE_EXTENSION_NAME, ElideExtension.class, project, buildConfiguration);
         ElideRuntimeResolution resolution = ElideRuntimeResolver.resolve(project, extension);
+        ElideFormatting.configure(project, resolution);
+        ElideDependencies.configure(project);
         resolution.preparationTask().configure(task -> task.usesService(buildConfiguration));
         Provider<Boolean> mavenInstallerEnabled = mavenInstallerEnabled(project, extension);
         Provider<Boolean> installEnabled = extension.getEnableInstall()
@@ -40,6 +41,10 @@ public class ElideGradlePlugin implements Plugin<Project> {
                 project, extension, resolution, installEnabled);
 
         project.afterEvaluate(ignored -> {
+            if (extension.getDependencyMode().get() == ElideDependencyMode.GRADLE
+                    && (extension.getEnableInstall().get() || mavenInstallerEnabled.get())) {
+                throw new org.gradle.api.GradleException("dependencyMode GRADLE requires install = false; declare JVM dependencies in Gradle and use its locking and verification.");
+            }
             if (mavenInstallerEnabled.get()) {
                 installMavenDepsSupport(project, extension);
             }
@@ -49,19 +54,32 @@ public class ElideGradlePlugin implements Plugin<Project> {
                     if (!enableJavaCompiler(project, extension)) {
                         return;
                     }
-                    configureJavaCompileToUseElide(task, resolution);
+                    configureJavaCompileToUseElide(task, resolution, extension);
                     addManagedPreparationDependency(task, resolution);
                     task.dependsOn(installTask);
                 }));
     }
 
-    private void configureJavaCompileToUseElide(JavaCompile task, ElideRuntimeResolution resolution) {
+    private void configureJavaCompileToUseElide(JavaCompile task, ElideRuntimeResolution resolution, ElideExtension extension) {
         var options = task.getOptions();
         options.setFork(true);
-        options.getForkOptions().setExecutable(javaExecutable().toString());
         ElideCompilerArgumentProvider arguments = task.getProject().getObjects()
                 .newInstance(ElideCompilerArgumentProvider.class);
         arguments.getElideExecutable().set(resolution.executable());
+        ElideTaskInputs.runtime(task, resolution);
+        task.getInputs().property("elide.launcherJavaVersion", System.getProperty("java.runtime.version"));
+        task.getInputs().property("elide.runtimeVersion", extension.getRuntimeVersion());
+        for (String name : List.of("CLASSPATH", "JAVA_TOOL_OPTIONS", "JDK_JAVA_OPTIONS", "_JAVA_OPTIONS")) {
+            task.getInputs().property("elide.environment." + name,
+                    task.getProject().getProviders().environmentVariable(name).orElse(""));
+        }
+        arguments.getPersistentCompiler().set(extension.getPersistentCompiler());
+        arguments.getDependencyMode().set(extension.getDependencyMode());
+        var compilerService = task.getProject().getGradle().getSharedServices().registerIfAbsent(
+                "elideCompiler", ElideCompilerService.class, ignored -> {});
+        arguments.getCompilerService().set(compilerService);
+        arguments.getWorkerClasspath().from(task.getClasspath());
+        task.usesService(compilerService);
         arguments.getLauncherClasspath().from(compilerLauncherFile());
         arguments.getForwardedJvmArguments().set(task.getProject().provider(() -> {
             List<String> configured = options.getForkOptions().getJvmArgs();
@@ -71,14 +89,16 @@ public class ElideGradlePlugin implements Plugin<Project> {
         task.doFirst(ignored -> {
             arguments.getForwardedJvmArguments().finalizeValue();
             options.getForkOptions().setJvmArgs(List.of());
+            // The executable override is execution machinery. Compiler identity is fingerprinted
+            // by ElideCompilerArgumentProvider; keeping this unset during snapshotting avoids
+            // Gradle's blanket cache exclusion for otherwise untracked custom compilers.
+            var compiler = task.getJavaCompiler().getOrNull();
+            File home = compiler == null ? new File(System.getProperty("java.home"))
+                    : compiler.getMetadata().getInstallationPath().getAsFile();
+            options.getForkOptions().setExecutable(new File(home, "bin/" +
+                    (System.getProperty("os.name").toLowerCase().startsWith("windows")
+                            ? "java.exe" : "java")).getAbsolutePath());
         });
-    }
-
-    private static Path javaExecutable() {
-        String executableName = System.getProperty("os.name").toLowerCase().startsWith("windows")
-                ? "java.exe"
-                : "java";
-        return Path.of(System.getProperty("java.home"), "bin", executableName);
     }
 
     private static File compilerLauncherFile() {

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideJavaCompilerLauncher.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideJavaCompilerLauncher.java
@@ -37,7 +37,9 @@ public final class ElideJavaCompilerLauncher {
             var out = new java.io.DataOutputStream(socket.getOutputStream());
             out.writeUTF(endpoint[1]);
             out.writeUTF(arguments[3]);
-            out.writeUTF(System.getProperty("user.dir"));
+            // Direct System.getProperty calls are instrumented by Gradle 7.x, but this
+            // launcher runs in a standalone JVM without Gradle's instrumentation classes.
+            out.writeUTF(java.nio.file.Path.of("").toAbsolutePath().toString());
             if (!arguments[2].startsWith("request=") || !arguments[4].equals("javac")) {
                 throw new IOException("Malformed worker launcher arguments");
             }

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideJavaCompilerLauncher.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideJavaCompilerLauncher.java
@@ -10,15 +10,52 @@ public final class ElideJavaCompilerLauncher {
     }
 
     public static void main(String[] arguments) throws IOException, InterruptedException {
+        boolean gradleClasspath = arguments.length > 0 && arguments[0].equals("--gradle-classpath");
+        if (gradleClasspath) arguments = Arrays.copyOfRange(arguments, 1, arguments.length);
+        if (arguments.length > 0 && arguments[0].equals("--worker")) {
+            runWorker(arguments);
+            return;
+        }
         if (arguments.length < 2) {
             throw new IllegalArgumentException("Expected an Elide executable and compiler arguments");
         }
-        Process process = start(new ProcessBuilder(Arrays.asList(arguments)).inheritIO());
+        ProcessBuilder builder = new ProcessBuilder(Arrays.asList(arguments)).inheritIO();
+        if (gradleClasspath) builder.environment().remove("CLASSPATH");
+        Process process = start(builder);
         int exitCode = process.waitFor();
         if (exitCode != 0) {
             System.exit(exitCode);
         }
     }
+    private static void runWorker(String[] arguments) throws IOException {
+        if (arguments.length < 6) throw new IOException("Missing worker compiler arguments");
+        String[] endpoint = arguments[1].split(":", 2);
+        try (java.net.Socket socket = new java.net.Socket()) {
+            socket.connect(new java.net.InetSocketAddress(java.net.InetAddress.getLoopbackAddress(),
+                    Integer.parseInt(endpoint[0])), 10_000);
+            socket.setSoTimeout(310_000);
+            var out = new java.io.DataOutputStream(socket.getOutputStream());
+            out.writeUTF(endpoint[1]);
+            out.writeUTF(arguments[3]);
+            out.writeUTF(System.getProperty("user.dir"));
+            if (!arguments[2].startsWith("request=") || !arguments[4].equals("javac")) {
+                throw new IOException("Malformed worker launcher arguments");
+            }
+            out.writeUTF(arguments[2].substring("request=".length()));
+            out.writeInt(arguments.length - 5);
+            for (int i = 5; i < arguments.length; i++) out.writeUTF(arguments[i]);
+            out.flush();
+            var in = new java.io.DataInputStream(socket.getInputStream());
+            int code = in.readInt();
+            int length = in.readInt();
+            if (length < 0 || length > 64 * 1024 * 1024) throw new IOException("Invalid worker output length");
+            byte[] output = in.readNBytes(length);
+            if (output.length != length) throw new IOException("Truncated worker output");
+            System.err.write(output);
+            if (code != 0) System.exit(code);
+        }
+    }
+
     private static Process start(ProcessBuilder builder) throws IOException {
         try {
             // Gradle 7 instruments direct start() calls with Gradle-only classes. This launcher

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideTaskInputs.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideTaskInputs.java
@@ -1,0 +1,34 @@
+package dev.elide.gradle;
+
+import org.gradle.api.Task;
+import org.gradle.api.tasks.PathSensitivity;
+
+import java.io.File;
+
+final class ElideTaskInputs {
+    static void runtime(Task task, ElideRuntimeResolution resolution) {
+        task.getInputs()
+                .property(
+                        "elide.platform",
+                        System.getProperty("os.name") + "/" + System.getProperty("os.arch"));
+        task.getInputs()
+                .files(
+                        resolution
+                                .source()
+                                .zip(
+                                        resolution.executable(),
+                                        (source, executable) ->
+                                                source == ElideRuntimeSource.MANAGED
+                                                        ? new File[] {
+                                                            new File(
+                                                                    executable
+                                                                            .getAsFile()
+                                                                            .getParentFile()
+                                                                            .getParentFile(),
+                                                                    ".complete")
+                                                        }
+                                                        : new File[0]))
+                .withPropertyName("elide.distributionChecksum")
+                .withPathSensitivity(PathSensitivity.NONE);
+    }
+}

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideWorkerProcess.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideWorkerProcess.java
@@ -1,0 +1,107 @@
+package dev.elide.gradle;
+
+import java.io.*;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+/** One serial Elide compiler worker, owned and closed by the build service. */
+final class ElideWorkerProcess implements AutoCloseable {
+    private final Process process;
+    private final ExecutorService reader =
+            Executors.newSingleThreadExecutor(
+                    r -> {
+                        Thread thread = new Thread(r, "elide-worker-response");
+                        thread.setDaemon(true);
+                        return thread;
+                    });
+    private int sequence;
+    private final ByteArrayOutputStream errorOutput = new ByteArrayOutputStream();
+
+    ElideWorkerProcess(String executable, Path directory) throws IOException {
+        this(List.of(executable, "javac", "--persistent_worker", "--classpath-cache"), directory);
+    }
+
+    ElideWorkerProcess(List<String> command, Path directory) throws IOException {
+        process = new ProcessBuilder(command).directory(directory.toFile()).start();
+        org.gradle.api.logging.Logging.getLogger(ElideWorkerProcess.class)
+                .info("Started Elide compiler worker (pid {})", process.pid());
+        Thread errors =
+                new Thread(
+                        () -> {
+                            try (InputStream input = process.getErrorStream()) {
+                                byte[] bytes = new byte[4096];
+                                int count;
+                                while ((count = input.read(bytes)) != -1) {
+                                    synchronized (errorOutput) {
+                                        errorOutput.write(
+                                                bytes,
+                                                0,
+                                                Math.min(count, 65536 - errorOutput.size()));
+                                    }
+                                }
+                            } catch (IOException ignored) {
+                            }
+                        },
+                        "elide-worker-stderr");
+        errors.setDaemon(true);
+        errors.start();
+    }
+
+    synchronized ElideWorkerProtocol.Response compile(
+            List<String> arguments, Map<String, byte[]> inputs) throws IOException {
+        int id = ++sequence;
+        Future<ElideWorkerProtocol.Response> response =
+                reader.submit(
+                        () -> {
+                            ElideWorkerProtocol.writeRequest(
+                                    process.getOutputStream(), arguments, inputs, id);
+                            return ElideWorkerProtocol.readResponse(process.getInputStream());
+                        });
+        try {
+            var result = response.get(5, TimeUnit.MINUTES);
+            if (result.requestId() != id) {
+                close();
+                throw new IOException("Elide worker returned an unexpected request ID");
+            }
+            return result;
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            close();
+            throw new IOException("Elide compilation interrupted", exception);
+        } catch (ExecutionException | TimeoutException exception) {
+            close();
+            Throwable cause =
+                    exception instanceof ExecutionException ? exception.getCause() : exception;
+            String diagnostics;
+            synchronized (errorOutput) {
+                diagnostics = errorOutput.toString(java.nio.charset.StandardCharsets.UTF_8);
+            }
+            throw new IOException(
+                    "Elide compiler worker failed: "
+                            + cause.getClass().getSimpleName()
+                            + ": "
+                            + cause.getMessage()
+                            + "\n"
+                            + diagnostics,
+                    exception);
+        }
+    }
+
+    boolean isAlive() {
+        return process.isAlive();
+    }
+
+    @Override
+    public void close() {
+        process.destroy();
+        try {
+            if (!process.waitFor(2, TimeUnit.SECONDS)) process.destroyForcibly();
+        } catch (InterruptedException exception) {
+            process.destroyForcibly();
+            Thread.currentThread().interrupt();
+        }
+        reader.shutdownNow();
+    }
+}

--- a/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideWorkerProtocol.java
+++ b/elide-gradle-plugin/src/main/java/dev/elide/gradle/ElideWorkerProtocol.java
@@ -1,0 +1,97 @@
+package dev.elide.gradle;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/** Minimal wire-compatible client for Bazel's length-delimited worker protocol. */
+final class ElideWorkerProtocol {
+    static final int MAX_FRAME = 64 * 1024 * 1024;
+
+    record Response(int exitCode, String output, int requestId) {}
+
+    static void writeRequest(
+            OutputStream stream, List<String> arguments, Map<String, byte[]> inputs, int id)
+            throws IOException {
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        for (String argument : arguments) field(body, 1, argument.getBytes(StandardCharsets.UTF_8));
+        for (var input : inputs.entrySet()) {
+            ByteArrayOutputStream entry = new ByteArrayOutputStream();
+            field(entry, 1, input.getKey().getBytes(StandardCharsets.UTF_8));
+            field(entry, 2, input.getValue());
+            field(body, 2, entry.toByteArray());
+        }
+        varint(body, 24);
+        varint(body, id);
+        if (body.size() > MAX_FRAME) throw new IOException("Elide worker request exceeds 64 MiB");
+        varint(stream, body.size());
+        body.writeTo(stream);
+        stream.flush();
+    }
+
+    static Response readResponse(InputStream stream) throws IOException {
+        int size = length(stream);
+        byte[] bytes = stream.readNBytes(size);
+        if (bytes.length != size) throw new EOFException("Truncated Elide worker response");
+        ByteArrayInputStream body = new ByteArrayInputStream(bytes);
+        int code = 0, id = 0;
+        String output = "";
+        while (body.available() > 0) {
+            long tag = varint(body);
+            if (tag == 8) code = (int) varint(body);
+            else if (tag == 18) output = new String(readBytes(body), StandardCharsets.UTF_8);
+            else if (tag == 24) id = (int) varint(body);
+            else {
+                switch ((int) (tag & 7)) {
+                    case 0 -> varint(body);
+                    case 1 -> body.skipNBytes(8);
+                    case 2 -> body.skipNBytes(length(body));
+                    case 5 -> body.skipNBytes(4);
+                    default -> throw new IOException("Invalid Elide worker field");
+                }
+            }
+        }
+        return new Response(code, output, id);
+    }
+
+    private static byte[] readBytes(InputStream input) throws IOException {
+        int size = length(input);
+        byte[] bytes = input.readNBytes(size);
+        if (bytes.length != size) throw new EOFException("Truncated worker field");
+        return bytes;
+    }
+
+    private static int length(InputStream input) throws IOException {
+        long size = varint(input);
+        if (size < 0 || size > MAX_FRAME)
+            throw new IOException("Invalid Elide worker frame length");
+        return (int) size;
+    }
+
+    private static void field(OutputStream out, int number, byte[] value) throws IOException {
+        varint(out, (number << 3) | 2);
+        varint(out, value.length);
+        out.write(value);
+    }
+
+    private static void varint(OutputStream out, long value) throws IOException {
+        while ((value & ~127L) != 0) {
+            out.write((int) (value & 127) | 128);
+            value >>>= 7;
+        }
+        out.write((int) value);
+    }
+
+    private static long varint(InputStream input) throws IOException {
+        long value = 0;
+        for (int shift = 0; shift < 64; shift += 7) {
+            int b = input.read();
+            if (b < 0) throw new EOFException("Truncated worker varint");
+            if (shift == 63 && (b & 254) != 0) throw new IOException("Worker varint overflow");
+            value |= (long) (b & 127) << shift;
+            if ((b & 128) == 0) return value;
+        }
+        throw new IOException("Worker varint overflow");
+    }
+}

--- a/elide-gradle-plugin/src/realRuntimeSmoke/java/dev/elide/gradle/RealRuntimeSmokeTest.java
+++ b/elide-gradle-plugin/src/realRuntimeSmoke/java/dev/elide/gradle/RealRuntimeSmokeTest.java
@@ -141,6 +141,7 @@ class RealRuntimeSmokeTest {
                     enableInstall.set(true)
                     enableMavenIntegration.set(true)
                     enableJavaCompiler.set(true)
+                    persistentCompiler.set(true)
                     manifest.set(layout.projectDirectory.file('elide.pkl'))
                 }
 

--- a/elide-gradle-plugin/src/test/java/dev/elide/gradle/ElideWorkerProcessTest.java
+++ b/elide-gradle-plugin/src/test/java/dev/elide/gradle/ElideWorkerProcessTest.java
@@ -1,0 +1,55 @@
+package dev.elide.gradle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+class ElideWorkerProcessTest {
+    @TempDir Path directory;
+
+    @Test
+    void preservesWorkerAcrossFailedRequestsAndClosesIt() throws Exception {
+        String java =
+                Path.of(
+                                System.getProperty("java.home"),
+                                "bin",
+                                System.getProperty("os.name").startsWith("Windows")
+                                        ? "java.exe"
+                                        : "java")
+                        .toString();
+        String classes =
+                Path.of(Fixture.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+                        .toString();
+        ElideWorkerProcess worker =
+                new ElideWorkerProcess(
+                        List.of(java, "-cp", classes, Fixture.class.getName()), directory);
+        try {
+            assertEquals(0, worker.compile(List.of("first"), Map.of()).exitCode());
+            assertEquals(1, worker.compile(List.of("invalid"), Map.of()).exitCode());
+            assertEquals(0, worker.compile(List.of("third"), Map.of()).exitCode());
+            assertTrue(worker.isAlive());
+        } finally {
+            worker.close();
+        }
+        assertFalse(worker.isAlive());
+    }
+
+    /** A separate JVM implements just enough of the server protocol to test client lifecycle. */
+    public static class Fixture {
+        public static void main(String[] args) throws Exception {
+            for (int id = 1; ; id++) {
+                int length = System.in.read();
+                if (length == -1) return;
+                byte[] request = System.in.readNBytes(length);
+                if (request.length != length || request[length - 1] != id) System.exit(9);
+                System.out.write(new byte[] {4, 8, (byte) (id == 2 ? 1 : 0), 24, (byte) id});
+                System.out.flush();
+            }
+        }
+    }
+}

--- a/elide-gradle-plugin/src/test/java/dev/elide/gradle/ElideWorkerProtocolTest.java
+++ b/elide-gradle-plugin/src/test/java/dev/elide/gradle/ElideWorkerProtocolTest.java
@@ -1,0 +1,41 @@
+package dev.elide.gradle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.util.List;
+import java.util.Map;
+
+class ElideWorkerProtocolTest {
+    @Test
+    void encodesCanonicalBazelRequest() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ElideWorkerProtocol.writeRequest(out, List.of("--", "A.java"), Map.of(), 7);
+        assertArrayEquals(
+                new byte[] {14, 10, 2, 45, 45, 10, 6, 65, 46, 106, 97, 118, 97, 24, 7},
+                out.toByteArray());
+    }
+
+    @Test
+    void readsResponseAndRejectsTruncatedFrame() throws Exception {
+        var response =
+                ElideWorkerProtocol.readResponse(
+                        new ByteArrayInputStream(new byte[] {8, 8, 1, 18, 2, 110, 111, 24, 7}));
+        assertEquals(1, response.exitCode());
+        assertEquals("no", response.output());
+        assertEquals(7, response.requestId());
+        assertThrows(
+                IOException.class,
+                () ->
+                        ElideWorkerProtocol.readResponse(
+                                new ByteArrayInputStream(new byte[] {10, 8})));
+        assertThrows(
+                IOException.class,
+                () ->
+                        ElideWorkerProtocol.readResponse(
+                                new ByteArrayInputStream(
+                                        new byte[] {(byte) 255, (byte) 255, (byte) 255, 127})));
+    }
+}


### PR DESCRIPTION
Java compilation now restores outputs after a clean build or checkout relocation while retaining Gradle's incremental source analysis and stale-class cleanup. This PR stacks on #5 (`feat/settings-plugin`) and reuses its runtime selection for compilation and formatting.

- Fingerprint the Elide executable, launcher, runtime version/platform, managed-distribution checksum, and JVM/classpath environment inputs. Defer launcher setup until execution so Gradle can cache the explicitly modeled compiler.
- Add opt-in `persistentCompiler` using Elide's existing Bazel protobuf worker protocol. A build service owns up to four processes, reuses compatible executable/working-directory pairs, supplies classpath JAR digests, and handles bounded responses, timeouts, and shutdown. Real main/test compilation uses one native process.
- Add cacheable staged `elideJavaFormat`/`elideKtfmt` tasks, non-mutating `elideCheckFormat`, and explicit `elideFormat` application.
- Add `dependencyMode = GRADLE`: reject the legacy installer and ignore ambient CLASSPATH so Gradle declarations own JVM resolution. `elideExportDependencies` produces portable, cacheable inventories of Gradle-selected runtime artifacts and SHA-256 checksums; conflict resolution, verification, locking, and offline policy remain Gradle's responsibility.

Validation: 87 tests passed, 2 platform-specific skips, 0 failures across unit, functional, compatibility, native integration, and managed-runtime smoke suites. All 10 native cases also passed against the exact CI runtime, Elide 1.5.1+20260903. Plugin validation and actionlint passed.

CI now uses commit-pinned `elide-dev/setup-elide` and requires `realNativeIntegrationTest` on Linux, macOS, Windows, and the current-toolchain build lanes. Missing runtime configuration fails instead of skipping; all lanes upload test reports. Native tests cover both compiler modes on Gradle 7.6.4/8.14.5/9.7.1 with HTTP cache upload/restoration (local cache disabled), checkout relocation, changed-source and deleted-class correctness. Additional cases verify real worker reuse/recovery, parallel isolation/configuration-cache reuse, replacement of a dependency JAR, real javaformat/ktfmt cache/check/apply/style/deletion behavior, and Gradle catalog/checksum-verification enforcement. The expanded matrix found and fixed a Gradle 7.6 standalone-launcher instrumentation bug; a stale Windows configuration-time assertion was also corrected and made cross-platform.

See `docs/testing.md` for coverage boundaries and the non-gating benchmark follow-up. Benchmarks are not implemented and no measured performance gain is claimed.

Scope limits: dependency-mode/export support is an initial slice of dependency unification; this PR does not import `elide.pkl` or interpret/rewrite `elide.lock.bin`. Workers are scoped to one build and compatible working directories, with a five-minute request timeout; fork JVM arguments require one-shot mode. Formatters use one-shot CLI calls because the inspected formatter entry points do not expose the compiler worker protocol. Remote cache transport is tested using loopback HTTP; authenticated/TLS hosted caches, cross-Gradle-User-Home relocation, annotation processors/JPMS, and real worker crash/timeout/cancellation coverage remain follow-ups.

