### PR TITLE
perf: track Java CLI clean builds with CodSpeed walltime

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,0 @@
-self-hosted-runner:
-  labels:
-    - codspeed-macro

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - codspeed-macro

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - linux-amd64-bench

--- a/.github/workflows/on.benchmark.yml
+++ b/.github/workflows/on.benchmark.yml
@@ -55,11 +55,13 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codspeed-macro
-    # Elide's pinned Linux ARM64 binary needs glibc 2.39; the runner host has an older libc.
+    # The pinned Elide image fails its CPU feature check on current CodSpeed Macro hardware.
+    # Use the same compatible ARM64 runner as smoke until a portable runtime is available.
+    runs-on: ubuntu-24.04-arm
+    # Keep userspace identical to smoke, including Elide's required glibc 2.39.
     container:
       image: ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
-      # CodSpeed's profiler configures kernel perf sysctls on the dedicated runner.
+      # CodSpeed's profiler configures kernel perf sysctls on the ephemeral runner.
       options: --privileged
     timeout-minutes: 30
     steps:

--- a/.github/workflows/on.benchmark.yml
+++ b/.github/workflows/on.benchmark.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           distribution: temurin
           java-version: "17.0.16+8"
+      - name: "Setup: Trust mounted checkout"
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: "Prepare and verify both builds"
         run: bash benchmarks/prepare.sh
       - name: "Reports: Verification logs"
@@ -78,6 +80,8 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
         with:
           cache-disabled: true
+      - name: "Setup: Trust mounted checkout"
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: "Prepare and verify both builds"
         run: bash benchmarks/prepare.sh
       - name: "Measure: Wall clock builds"

--- a/.github/workflows/on.benchmark.yml
+++ b/.github/workflows/on.benchmark.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   smoke:
     name: "Verify benchmark fixtures"
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     container:
       image: ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
     timeout-minutes: 15
@@ -55,13 +55,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    # The pinned Elide image fails its CPU feature check on current CodSpeed Macro hardware.
-    # Use the same compatible ARM64 runner as smoke until a portable runtime is available.
-    runs-on: ubuntu-24.04-arm
+    # Dedicated Elide benchmark cluster; use native amd64 execution for stable wall-clock data.
+    runs-on: linux-amd64-bench
     # Keep userspace identical to smoke, including Elide's required glibc 2.39.
     container:
       image: ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
-      # CodSpeed's profiler configures kernel perf sysctls on the ephemeral runner.
+      # CodSpeed's profiler configures kernel perf sysctls on the benchmark runner.
       options: --privileged
     timeout-minutes: 30
     steps:

--- a/.github/workflows/on.benchmark.yml
+++ b/.github/workflows/on.benchmark.yml
@@ -1,0 +1,79 @@
+name: "Build Benchmarks"
+
+"on":
+  pull_request: {}
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 13 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "benchmarks-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: "Verify benchmark fixtures"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: "Setup: Checkout"
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: "Setup: Java 17"
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "17.0.16+8"
+      - name: "Prepare and verify both builds"
+        run: bash benchmarks/prepare.sh
+      - name: "Reports: Verification logs"
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: build-benchmark-smoke
+          path: |
+            benchmarks/build/*.txt
+            benchmarks/build/*.log
+
+  walltime:
+    name: "Java CLI clean builds"
+    needs: smoke
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: codspeed-macro
+    timeout-minutes: 30
+    steps:
+      - name: "Setup: Checkout"
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: "Setup: Java 17"
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "17.0.16+8"
+      - name: "Setup: Gradle"
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+        with:
+          cache-disabled: true
+      - name: "Prepare and verify both builds"
+        run: bash benchmarks/prepare.sh
+      - name: "Measure: Wall clock builds"
+        uses: CodSpeedHQ/action@373d6868929f444bc08d901fd0eb0ad52a8875ea # v5.2.1
+        with:
+          mode: walltime
+      - name: "Reports: Environment and verification logs"
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: build-benchmark-diagnostics
+          path: |
+            benchmarks/build/*.txt
+            benchmarks/build/*.log

--- a/.github/workflows/on.benchmark.yml
+++ b/.github/workflows/on.benchmark.yml
@@ -87,6 +87,9 @@ jobs:
         run: bash benchmarks/prepare.sh
       - name: "Measure: Wall clock builds"
         uses: CodSpeedHQ/action@373d6868929f444bc08d901fd0eb0ad52a8875ea # v5.2.1
+        env:
+          # Use the benchmark runner/container CPU allocation; there is no systemd in this image.
+          CODSPEED_ISOLATION: "false"
         with:
           mode: walltime
       - name: "Reports: Environment and verification logs"

--- a/.github/workflows/on.benchmark.yml
+++ b/.github/workflows/on.benchmark.yml
@@ -18,9 +18,15 @@ concurrency:
 jobs:
   smoke:
     name: "Verify benchmark fixtures"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
     timeout-minutes: 15
     steps:
+      - name: "Setup: Container tools"
+        run: |
+          apt-get update
+          apt-get install --no-install-recommends -y ca-certificates curl git unzip
       - name: "Setup: Checkout"
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
@@ -48,8 +54,17 @@ jobs:
       contents: read
       id-token: write
     runs-on: codspeed-macro
+    # Elide's pinned Linux ARM64 binary needs glibc 2.39; the runner host has an older libc.
+    container:
+      image: ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+      # CodSpeed's profiler configures kernel perf sysctls on the dedicated runner.
+      options: --privileged
     timeout-minutes: 30
     steps:
+      - name: "Setup: Container tools"
+        run: |
+          apt-get update
+          apt-get install --no-install-recommends -y ca-certificates curl git unzip procps
       - name: "Setup: Checkout"
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ project directory; failures identify the executable, working directory, exit cod
 
 ### Compilation cache and persistent workers
 
+Track end-to-end Java CLI build time with the [CodSpeed build benchmarks](benchmarks/README.md),
+which compare stock javac and Elide using identical sources, tests, and packaging.
+
 `compileJava` and `compileTestJava` retain Gradle's standard task types, classpath analysis, outputs, and lifecycle wiring.
 With `--build-cache`, compiled output can be restored after `clean` or from another checkout. Compiler executable content,
 the launcher, runtime version, platform, managed-distribution checksum, and JVM/classpath environment overrides are inputs.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,11 +23,11 @@ compilation, CLI tests, and packaging. It is not an isolated compiler benchmark.
 The shell script overhead is included equally in both variants.
 
 - Gradle is pinned by the repository wrapper (currently 9.7.1).
-- CI uses Temurin `17.0.16+8` and CodSpeed Macro runners, inside a digest-pinned
+- CI uses Temurin `17.0.16+8` and GitHub `ubuntu-24.04-arm` runners, inside a digest-pinned
   Ubuntu 24.04 container. The pinned Elide Linux ARM64 binary requires glibc 2.39;
-  the Macro runner host's older libc cannot load it. Both variants use the same
+  older libc versions cannot load it. Both variants use the same
   container, which starts before timing. The measurement container permits
-  CodSpeed's profiler to configure kernel perf sysctls on the dedicated runner.
+  CodSpeed's profiler to configure kernel perf sysctls on the ephemeral runner.
   Local runs must set
   `JAVA_HOME` to a Java 17 JDK; measurements from other JDKs/machines are not CI baselines.
 - Both variants use two Gradle workers and disable persistent daemons, the build
@@ -81,14 +81,22 @@ uploads wall-clock results. Its action SHA pins the bundled runner version.
 CI artifacts retain preparation verification logs and toolchain metadata.
 An independent GitHub-hosted Ubuntu ARM64 smoke job uses the same container image
 and verifies both fixtures before the measurement job, even when a CodSpeed runner
-has not yet been enabled. Environment artifacts include the OS and glibc version.
+has not yet been enabled. Environment artifacts include the OS, glibc version,
+page size, and CPU features, and are captured before compilation so startup
+failures retain diagnostics.
 
-The repository must be activated in CodSpeed, and the organization must make its
-`codspeed-macro` runner group available to this public repository. Without that,
-GitHub will queue the measurement job waiting for a runner. Public uploads use
-GitHub OIDC (`id-token: write`); no repository upload secret is needed. See
+The repository must be activated in CodSpeed. Public uploads use GitHub OIDC
+(`id-token: write`); no repository upload secret is needed. See
 [CodSpeed authentication](https://codspeed.io/docs/integrations/ci/github-actions/configuration)
-and [Macro runner setup](https://codspeed.io/docs/instruments/walltime).
+and [walltime guidance](https://codspeed.io/docs/instruments/walltime).
+
+GitHub-hosted measurements have higher variance than dedicated Macro runners.
+Use these initial series for trends and investigation; do not enforce small
+regression thresholds. The pinned Elide runtime fails Graal's CPU feature check
+(isolate error 23) on current CodSpeed Macro hardware, even with compatible glibc.
+Returning to Macro runners requires a compatible runtime build or newer hardware;
+do not bypass the CPU check or use emulation for performance measurements. Establish
+new series/baselines when changing runner hardware.
 
 PR comparisons need a recorded baseline. The first merge to `main` seeds that
 baseline; stacked branches may initially show results without a base comparison.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,7 +35,8 @@ The shell script overhead is included equally in both variants.
   measurement rounds. The CI job has a 30-minute timeout.
 - Preparation verifies two consecutive offline builds of each variant: compilation,
   test execution, JAR and distribution tasks must execute each time, and both JARs
-  must print `Hello, Ada Lovelace!`. Failed commands fail the job.
+  must print `Hello, Ada Lovelace!`. Elide must report native compilation of both
+  source sets, guarding against accidental fallback to javac. Failed commands fail the job.
 
 Keep the series names stable to retain history. Change names when changing the
 measurement contract (for example, adding a warm-daemon or incremental scenario).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -27,6 +27,8 @@ The shell script overhead is included equally in both variants.
   `17.0.16+8`, inside a digest-pinned Ubuntu 24.04 container. Both variants use the same
   container, which starts before timing. The measurement container permits
   CodSpeed's profiler to configure kernel perf sysctls on the benchmark runner.
+  `CODSPEED_ISOLATION=false` uses the runner/container CPU allocation without
+  requesting a second systemd scope inside the container.
   Local runs must set
   `JAVA_HOME` to a Java 17 JDK; measurements from other JDKs/machines are not CI baselines.
 - Both variants use two Gradle workers and disable persistent daemons, the build

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,89 @@
+# Build benchmarks
+
+Two independent single-module Java 17 CLI projects share all application sources,
+tests, and packaging configuration:
+
+| CodSpeed series | Compiler |
+| --- | --- |
+| `java-cli/clean-build/javac` | Standard Gradle `JavaCompile` / JDK javac |
+| `java-cli/clean-build/elide` | This checkout's Elide plugin, managed Elide `1.5.1+20260903` |
+
+The Elide variant uses the default one-shot compiler and Gradle-owned dependencies.
+Its plugin JAR is built and copied before measurement. Neither measured project
+includes the plugin build. The application has no external dependencies; its
+small test harness also requires no libraries. Both builds compile main and test
+sources, execute the same assertions, and produce a JAR plus application ZIP/TAR.
+The standard framework-based `test` task is disabled; `check` runs `cliTest` instead.
+
+## Measurement contract
+
+Each sample measures `clean build` end to end, including the wrapper/client,
+single-use Gradle daemon startup/shutdown, project configuration, cleaning,
+compilation, CLI tests, and packaging. It is not an isolated compiler benchmark.
+The shell script overhead is included equally in both variants.
+
+- Gradle is pinned by the repository wrapper (currently 9.7.1).
+- CI uses Temurin `17.0.16+8` and CodSpeed Macro runners. Local runs must set
+  `JAVA_HOME` to a Java 17 JDK; measurements from other JDKs/machines are not CI baselines.
+- Both variants use two Gradle workers and disable persistent daemons, the build
+  cache, and the configuration cache. Compilation outputs are removed each round.
+- Preparation provisions Elide, compiles the plugin, and warms script/dependency
+  caches outside measurement. Measured builds run offline using a dedicated
+  `benchmarks/build/gradle-home`, excluding user Gradle configuration/init scripts.
+  OS filesystem caches remain warm. This is not a first-install benchmark.
+- CodSpeed runs the variants sequentially with 20 seconds of warmup and ten
+  measurement rounds. The CI job has a 30-minute timeout.
+- Preparation verifies two consecutive offline builds of each variant: compilation,
+  test execution, JAR and distribution tasks must execute each time, and both JARs
+  must print `Hello, Ada Lovelace!`. Failed commands fail the job.
+
+Keep the series names stable to retain history. Change names when changing the
+measurement contract (for example, adding a warm-daemon or incremental scenario).
+This tiny fixture intentionally captures fixed build overhead. It does not establish
+performance for large applications, annotation processors, incremental compilation,
+cache restoration, or persistent compiler workers. Add separate series for those.
+
+## Run locally
+
+```sh
+export JAVA_HOME=/path/to/jdk-17
+bash benchmarks/prepare.sh
+bash benchmarks/run.sh javac
+bash benchmarks/run.sh elide
+```
+
+Preparation includes correctness verification; rerun it after plugin changes to
+refresh the copied JAR. To repeat only correctness checks, use
+`bash benchmarks/verify.sh`. Verification logs and environment metadata are in
+`benchmarks/build/` (ignored by Git).
+
+For tracked measurements on Linux, install the [CodSpeed CLI](https://codspeed.io/docs/cli),
+authenticate/link the repository, prepare as above, and run from the repository root:
+
+```sh
+codspeed run --mode walltime
+```
+
+The pinned CodSpeed 5.2.1 command harness has no macOS ARM download. The shell-based
+build verification above works on macOS; use Linux/CI for CodSpeed measurement.
+
+## Continuous reporting
+
+`.github/workflows/on.benchmark.yml` runs on pull requests, pushes to `main`, daily,
+and manual dispatch. The CodSpeed action reads root `codspeed.yml` directly and
+uploads wall-clock results. Its action SHA pins the bundled runner version.
+CI artifacts retain preparation verification logs and toolchain metadata.
+An independent GitHub-hosted Ubuntu smoke job verifies both fixtures before the
+measurement job, even when a CodSpeed runner has not yet been enabled.
+
+The repository must be activated in CodSpeed, and the organization must make its
+`codspeed-macro` runner group available to this public repository. Without that,
+GitHub will queue the measurement job waiting for a runner. Public uploads use
+GitHub OIDC (`id-token: write`); no repository upload secret is needed. See
+[CodSpeed authentication](https://codspeed.io/docs/integrations/ci/github-actions/configuration)
+and [Macro runner setup](https://codspeed.io/docs/instruments/walltime).
+
+PR comparisons need a recorded baseline. The first merge to `main` seeds that
+baseline; stacked branches may initially show results without a base comparison.
+Start with reporting and inspect normal variation before making regression checks
+required. No speedup or regression threshold is asserted by this initial suite.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,11 +23,10 @@ compilation, CLI tests, and packaging. It is not an isolated compiler benchmark.
 The shell script overhead is included equally in both variants.
 
 - Gradle is pinned by the repository wrapper (currently 9.7.1).
-- CI uses Temurin `17.0.16+8` and GitHub `ubuntu-24.04-arm` runners, inside a digest-pinned
-  Ubuntu 24.04 container. The pinned Elide Linux ARM64 binary requires glibc 2.39;
-  older libc versions cannot load it. Both variants use the same
+- CI measures on Elide's dedicated `linux-amd64-bench` cluster using Temurin
+  `17.0.16+8`, inside a digest-pinned Ubuntu 24.04 container. Both variants use the same
   container, which starts before timing. The measurement container permits
-  CodSpeed's profiler to configure kernel perf sysctls on the ephemeral runner.
+  CodSpeed's profiler to configure kernel perf sysctls on the benchmark runner.
   Local runs must set
   `JAVA_HOME` to a Java 17 JDK; measurements from other JDKs/machines are not CI baselines.
 - Both variants use two Gradle workers and disable persistent daemons, the build
@@ -79,9 +78,9 @@ build verification above works on macOS; use Linux/CI for CodSpeed measurement.
 and manual dispatch. The CodSpeed action reads root `codspeed.yml` directly and
 uploads wall-clock results. Its action SHA pins the bundled runner version.
 CI artifacts retain preparation verification logs and toolchain metadata.
-An independent GitHub-hosted Ubuntu ARM64 smoke job uses the same container image
-and verifies both fixtures before the measurement job, even when a CodSpeed runner
-has not yet been enabled. Environment artifacts include the OS, glibc version,
+An independent GitHub-hosted Ubuntu AMD64 smoke job uses the same container image
+and verifies both fixtures before measurement on `linux-amd64-bench`.
+Environment artifacts include the OS, glibc version,
 page size, and CPU features, and are captured before compilation so startup
 failures retain diagnostics.
 
@@ -90,13 +89,14 @@ The repository must be activated in CodSpeed. Public uploads use GitHub OIDC
 [CodSpeed authentication](https://codspeed.io/docs/integrations/ci/github-actions/configuration)
 and [walltime guidance](https://codspeed.io/docs/instruments/walltime).
 
-GitHub-hosted measurements have higher variance than dedicated Macro runners.
-Use these initial series for trends and investigation; do not enforce small
-regression thresholds. The pinned Elide runtime fails Graal's CPU feature check
-(isolate error 23) on current CodSpeed Macro hardware, even with compatible glibc.
-Returning to Macro runners requires a compatible runtime build or newer hardware;
-do not bypass the CPU check or use emulation for performance measurements. Establish
-new series/baselines when changing runner hardware.
+The benchmark job requires the `linux-amd64-bench` runner label to be available to
+this repository. Keep machines serving that label consistent in CPU and operating
+environment; establish new series/baselines when changing runner hardware.
+
+Two Elide Linux ARM64 compatibility failures observed on CodSpeed Macro runners
+are tracked separately: [glibc symbol requirements](https://github.com/elide-dev/WHIPLASH/issues/1739)
+and [CPU feature requirements](https://github.com/elide-dev/WHIPLASH/issues/1738).
+The benchmarks execute natively on the AMD64 cluster, without emulation or CPU-check overrides.
 
 PR comparisons need a recorded baseline. The first merge to `main` seeds that
 baseline; stacked branches may initially show results without a base comparison.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,7 +23,12 @@ compilation, CLI tests, and packaging. It is not an isolated compiler benchmark.
 The shell script overhead is included equally in both variants.
 
 - Gradle is pinned by the repository wrapper (currently 9.7.1).
-- CI uses Temurin `17.0.16+8` and CodSpeed Macro runners. Local runs must set
+- CI uses Temurin `17.0.16+8` and CodSpeed Macro runners, inside a digest-pinned
+  Ubuntu 24.04 container. The pinned Elide Linux ARM64 binary requires glibc 2.39;
+  the Macro runner host's older libc cannot load it. Both variants use the same
+  container, which starts before timing. The measurement container permits
+  CodSpeed's profiler to configure kernel perf sysctls on the dedicated runner.
+  Local runs must set
   `JAVA_HOME` to a Java 17 JDK; measurements from other JDKs/machines are not CI baselines.
 - Both variants use two Gradle workers and disable persistent daemons, the build
   cache, and the configuration cache. Compilation outputs are removed each round.
@@ -74,8 +79,9 @@ build verification above works on macOS; use Linux/CI for CodSpeed measurement.
 and manual dispatch. The CodSpeed action reads root `codspeed.yml` directly and
 uploads wall-clock results. Its action SHA pins the bundled runner version.
 CI artifacts retain preparation verification logs and toolchain metadata.
-An independent GitHub-hosted Ubuntu smoke job verifies both fixtures before the
-measurement job, even when a CodSpeed runner has not yet been enabled.
+An independent GitHub-hosted Ubuntu ARM64 smoke job uses the same container image
+and verifies both fixtures before the measurement job, even when a CodSpeed runner
+has not yet been enabled. Environment artifacts include the OS and glibc version.
 
 The repository must be activated in CodSpeed, and the organization must make its
 `codspeed-macro` runner group available to this public repository. Without that,

--- a/benchmarks/elide/build.gradle
+++ b/benchmarks/elide/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    // Prepared from this checkout before timing; no included plugin build in the measured graph.
+    dependencies {
+        classpath files('../build/elide-gradle-plugin.jar')
+    }
+}
+
+apply from: '../shared/build.gradle'
+apply plugin: 'dev.elide'
+
+elide {
+    dependencyMode.set(dev.elide.gradle.ElideDependencyMode.GRADLE)
+    runtime {
+        mode = dev.elide.gradle.ElideRuntimeMode.MANAGED
+        version = '1.5.1+20260903'
+    }
+}

--- a/benchmarks/elide/settings.gradle
+++ b/benchmarks/elide/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'hello-cli'

--- a/benchmarks/javac/build.gradle
+++ b/benchmarks/javac/build.gradle
@@ -1,0 +1,1 @@
+apply from: '../shared/build.gradle'

--- a/benchmarks/javac/settings.gradle
+++ b/benchmarks/javac/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'hello-cli'

--- a/benchmarks/prepare.sh
+++ b/benchmarks/prepare.sh
@@ -7,6 +7,20 @@ export GRADLE_USER_HOME="$root/benchmarks/build/gradle-home"
 cd "$root"
 mkdir -p benchmarks/build
 
+# Capture the environment before compilation, including when runtime startup fails.
+{
+  git rev-parse HEAD
+  ./gradlew --version
+  cat gradle.properties
+  uname -a
+  if [[ -f /etc/os-release ]]; then
+    cat /etc/os-release
+    getconf GNU_LIBC_VERSION
+    getconf PAGESIZE
+    sed -n '1,/^$/p' /proc/cpuinfo
+  fi
+} > benchmarks/build/environment.txt
+
 # Compile the plugin once, outside CodSpeed. The measured consumer loads only its JAR.
 ./gradlew --no-daemon --console=plain :elide-gradle-plugin:jar
 version=$(sed -n 's/^version=//p' gradle.properties)
@@ -23,15 +37,3 @@ for variant in javac elide; do
 done
 
 bash benchmarks/verify.sh
-
-# Keep toolchain identity with the CI artifacts for later interpretation.
-{
-  git rev-parse HEAD
-  ./gradlew --version
-  cat gradle.properties
-  uname -a
-  if [[ -f /etc/os-release ]]; then
-    cat /etc/os-release
-    getconf GNU_LIBC_VERSION
-  fi
-} > benchmarks/build/environment.txt

--- a/benchmarks/prepare.sh
+++ b/benchmarks/prepare.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export GRADLE_USER_HOME="$root/benchmarks/build/gradle-home"
+: "${JAVA_HOME:?Set JAVA_HOME to a Java 17 JDK}"
+cd "$root"
+mkdir -p benchmarks/build
+
+# Compile the plugin once, outside CodSpeed. The measured consumer loads only its JAR.
+./gradlew --no-daemon --console=plain :elide-gradle-plugin:jar
+version=$(sed -n 's/^version=//p' gradle.properties)
+cp "elide-gradle-plugin/build/libs/elide-gradle-plugin-$version.jar" \
+  benchmarks/build/elide-gradle-plugin.jar
+
+# Resolve the pinned managed runtime and warm Gradle's script/dependency caches.
+for variant in javac elide; do
+  ./gradlew -p "benchmarks/$variant" --no-daemon --no-build-cache \
+    --no-configuration-cache --max-workers=2 --console=plain \
+    -Porg.gradle.java.installations.auto-detect=false \
+    -Porg.gradle.java.installations.auto-download=false \
+    "-Porg.gradle.java.installations.paths=$JAVA_HOME" clean build
+done
+
+bash benchmarks/verify.sh
+
+# Keep toolchain identity with the CI artifacts for later interpretation.
+{
+  git rev-parse HEAD
+  ./gradlew --version
+  cat gradle.properties
+  uname -a
+} > benchmarks/build/environment.txt

--- a/benchmarks/prepare.sh
+++ b/benchmarks/prepare.sh
@@ -30,4 +30,8 @@ bash benchmarks/verify.sh
   ./gradlew --version
   cat gradle.properties
   uname -a
+  if [[ -f /etc/os-release ]]; then
+    cat /etc/os-release
+    getconf GNU_LIBC_VERSION
+  fi
 } > benchmarks/build/environment.txt

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export GRADLE_USER_HOME="$root/benchmarks/build/gradle-home"
+: "${JAVA_HOME:?Set JAVA_HOME to a Java 17 JDK}"
+variant=${1:?Usage: benchmarks/run.sh javac|elide}
+case "$variant" in
+  javac|elide) ;;
+  *) echo "Unknown benchmark variant: $variant" >&2; exit 2 ;;
+esac
+
+# clean is deliberately inside the measurement. No downloads or cached task outputs.
+exec "$root/gradlew" -p "$root/benchmarks/$variant" \
+  --offline --no-daemon --no-build-cache --no-configuration-cache \
+  --max-workers=2 --console=plain \
+  -Porg.gradle.java.installations.auto-detect=false \
+  -Porg.gradle.java.installations.auto-download=false \
+  "-Porg.gradle.java.installations.paths=$JAVA_HOME" clean build

--- a/benchmarks/shared/build.gradle
+++ b/benchmarks/shared/build.gradle
@@ -1,0 +1,35 @@
+apply plugin: 'application'
+
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(17)
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 17
+}
+
+sourceSets {
+    main.java.setSrcDirs([file('../shared/src/main/java')])
+    test.java.setSrcDirs([file('../shared/src/test/java')])
+}
+
+application {
+    mainClass = 'dev.elide.benchmark.Main'
+}
+
+// Both variants compile and execute precisely the same tests, without a test framework dependency.
+tasks.register('cliTest', JavaExec) {
+    dependsOn tasks.named('testClasses')
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'dev.elide.benchmark.CliTest'
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+tasks.named('check') {
+    dependsOn tasks.named('cliTest')
+}
+// Tests use the JavaExec harness above, rather than Gradle's framework-based Test task.
+tasks.named('test') {
+    enabled = false
+}

--- a/benchmarks/shared/src/main/java/dev/elide/benchmark/Greeting.java
+++ b/benchmarks/shared/src/main/java/dev/elide/benchmark/Greeting.java
@@ -1,0 +1,7 @@
+package dev.elide.benchmark;
+
+final class Greeting {
+    static String message(String[] names) {
+        return "Hello, " + (names.length == 0 ? "world" : String.join(" ", names)) + "!";
+    }
+}

--- a/benchmarks/shared/src/main/java/dev/elide/benchmark/Main.java
+++ b/benchmarks/shared/src/main/java/dev/elide/benchmark/Main.java
@@ -1,0 +1,7 @@
+package dev.elide.benchmark;
+
+public final class Main {
+    public static void main(String[] args) {
+        System.out.println(Greeting.message(args));
+    }
+}

--- a/benchmarks/shared/src/test/java/dev/elide/benchmark/CliTest.java
+++ b/benchmarks/shared/src/test/java/dev/elide/benchmark/CliTest.java
@@ -1,0 +1,16 @@
+package dev.elide.benchmark;
+
+/** Dependency-free smoke test, executed by both builds as part of check. */
+public final class CliTest {
+    public static void main(String[] args) {
+        expect("Hello, world!", Greeting.message(new String[0]));
+        expect("Hello, Ada!", Greeting.message(new String[] {"Ada"}));
+        expect("Hello, Ada Lovelace!", Greeting.message(new String[] {"Ada", "Lovelace"}));
+    }
+
+    private static void expect(String expected, String actual) {
+        if (!expected.equals(actual)) {
+            throw new AssertionError("Expected: " + expected + "; actual: " + actual);
+        }
+    }
+}

--- a/benchmarks/verify.sh
+++ b/benchmarks/verify.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$root"
+mkdir -p benchmarks/build
+java_command=${JAVA_HOME:+$JAVA_HOME/bin/}java
+
+# Use the exact measured commands offline, twice: every round must really compile.
+for variant in javac elide; do
+  for round in 1 2; do
+    log="benchmarks/build/$variant-$round.log"
+    bash benchmarks/run.sh "$variant" > "$log" 2>&1 || { cat "$log"; exit 1; }
+    for task in compileJava compileTestJava cliTest jar distTar distZip; do
+      if ! grep -qx "> Task :$task" "$log"; then
+        echo "$variant round $round did not execute $task" >&2
+        cat "$log"
+        exit 1
+      fi
+    done
+    actual=$("$java_command" -cp "benchmarks/$variant/build/libs/hello-cli.jar" \
+      dev.elide.benchmark.Main Ada Lovelace)
+    if [[ "$actual" != 'Hello, Ada Lovelace!' ]]; then
+      echo "Unexpected CLI output for $variant: $actual" >&2
+      exit 1
+    fi
+  done
+done
+echo 'Both compiler variants rebuilt, tested, packaged, and ran successfully in two offline rounds.'

--- a/benchmarks/verify.sh
+++ b/benchmarks/verify.sh
@@ -18,6 +18,16 @@ for variant in javac elide; do
         exit 1
       fi
     done
+    if [[ "$variant" == elide ]]; then
+      # The pinned native compiler reports each source set. Catch accidental fallback to javac.
+      for source_set in main test; do
+        if ! grep -q "Java sources compiled to .$source_set." "$log"; then
+          echo "Elide did not report compiling $source_set in round $round" >&2
+          cat "$log"
+          exit 1
+        fi
+      done
+    fi
     actual=$("$java_command" -cp "benchmarks/$variant/build/libs/hello-cli.jar" \
       dev.elide.benchmark.Main Ada Lovelace)
     if [[ "$actual" != 'Hello, Ada Lovelace!' ]]; then

--- a/codspeed.yml
+++ b/codspeed.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/CodSpeedHQ/codspeed/refs/heads/main/schemas/codspeed.schema.json
+options:
+  warmup-time: 20s
+  max-rounds: 10
+
+benchmarks:
+  - name: java-cli/clean-build/javac
+    exec: bash benchmarks/run.sh javac
+  - name: java-cli/clean-build/elide
+    exec: bash benchmarks/run.sh elide


### PR DESCRIPTION
Adds continuous wall-clock measurement for the same single-module Java CLI built with stock javac and with this checkout's Elide plugin. Stacked on #7 (`feat/native-integration`).

Both stable CodSpeed series measure offline `clean build`, including single-use Gradle startup, main/test compilation, dependency-free CLI assertions, and JAR/ZIP/TAR packaging. Sources and build configuration are shared. Plugin compilation and managed runtime provisioning happen before timing; build/configuration caches and persistent Gradle daemons are disabled. The Elide series measures the default one-shot compiler.

Measurements run natively on our dedicated `linux-amd64-bench` cluster. An independent GitHub-hosted AMD64 smoke job verifies the fixtures first. Both jobs use the same digest-pinned Ubuntu 24.04 userspace and pinned Temurin JDK. Container setup is outside measurement. The workflow runs for PRs, main pushes, a daily schedule, and manual dispatch. Diagnostic artifacts capture OS, glibc, CPU features, page size, and commit metadata before compilation.

Validation: [the benchmark workflow passes](https://github.com/elide-dev/gradle/actions/runs/33944018395), including the AMD64 fixture smoke and measurement on `linux-amd64-bench`. Both series completed ten timed rounds, and CodSpeed confirmed performance data upload; its Performance Analysis check passes. Workflow lint and shell syntax checks also pass. `CODSPEED_ISOLATION=false` uses the runner/container CPU allocation without requiring systemd inside the container.

Runtime portability failures discovered on CodSpeed Macro ARM64 hardware are tracked separately:
- https://github.com/elide-dev/WHIPLASH/issues/1739 — required glibc symbols unavailable on the host.
- https://github.com/elide-dev/WHIPLASH/issues/1738 — CPU feature check fails after compatible userspace is supplied.

Main must record the initial baseline before normal PR comparisons are available. No performance claims or mandatory regression thresholds yet.
